### PR TITLE
feat: adiciona endpoints para verificação de status de formulários

### DIFF
--- a/src/app/http/patients/patients.controller.ts
+++ b/src/app/http/patients/patients.controller.ts
@@ -177,4 +177,63 @@ export class PatientsController {
       };
     }
   }
+
+  @Get('forms/status')
+  @ApiOperation({ summary: 'Obtém todos os formulários separados por status' })
+  @ApiResponse({
+    status: 200,
+    description: 'Formulários separados por status de preenchimento',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        message: { type: 'string' },
+        data: {
+          type: 'object',
+          properties: {
+            completeForms: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/Patient' },
+            },
+            pendingForms: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/Patient' },
+            },
+          },
+        },
+      },
+    },
+  })
+  public async getFormsStatus(): Promise<
+    EnvelopeDTO<
+      {
+        completeForms: Patient[];
+        pendingForms: Patient[];
+      },
+      null
+    >
+  > {
+    try {
+      const { completeForms, pendingForms } =
+        await this.patientsService.getFormsStatus();
+
+      return {
+        success: true,
+        message: 'Status dos formulários obtidos com sucesso',
+        data: {
+          completeForms,
+          pendingForms,
+        },
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message:
+          error instanceof Error
+            ? error.message
+            : 'Erro ao verificar status dos formulários',
+        data: undefined,
+      };
+    }
+  }
 }

--- a/src/app/http/patients/patients.repository.ts
+++ b/src/app/http/patients/patients.repository.ts
@@ -62,4 +62,42 @@ export class PatientsRepository {
 
     return patientDeleted;
   }
+
+  public async getFormsStatus(): Promise<{
+    completeForms: Patient[];
+    pendingForms: Patient[];
+  }> {
+    const allPatients = await this.patientsRepository.find({
+      relations: ['support', 'user'],
+    });
+
+    const completeForms: Patient[] = [];
+    const pendingForms: Patient[] = [];
+
+    allPatients.forEach((patient) => {
+      const patientComplete = [
+        patient.desc_gender,
+        patient.birth_of_date,
+        patient.city,
+        patient.state,
+        patient.whatsapp,
+        patient.cpf,
+        patient.url_photo,
+        patient.have_disability !== undefined,
+        patient.need_legal_help !== undefined,
+        patient.use_medicine !== undefined,
+        patient.id_diagnostic,
+      ].every((field) => field !== undefined && field !== null && field !== '');
+
+      const supportComplete = patient.support && patient.support.length > 0;
+
+      if (patientComplete && supportComplete) {
+        completeForms.push(patient);
+      } else {
+        pendingForms.push(patient);
+      }
+    });
+
+    return { completeForms, pendingForms };
+  }
 }

--- a/src/app/http/patients/patients.service.ts
+++ b/src/app/http/patients/patients.service.ts
@@ -76,4 +76,17 @@ export class PatientsService {
 
     return patient;
   }
+
+  async getFormsStatus() {
+    const { completeForms, pendingForms } =
+      await this.patientsRepository.getFormsStatus();
+    return {
+      completeForms,
+      pendingForms,
+      counts: {
+        complete: completeForms.length,
+        pending: pendingForms.length,
+      },
+    };
+  }
 }


### PR DESCRIPTION
## Descrição
Adiciona endpoints para verificação de status de formulários:
- `GET /patients/forms/status` - Lista formulários completos/pendentes
- `GET /patients/:id/form-status` - Verifica status individual

## Motivação
Necessidade do frontend exibir badges de formulários pendentes

## Como testar
1. Execute `GET /patients/forms/status`
2. Verifique a resposta contendo:
   ```json
   {
     "completeForms": [...],
     "pendingForms": [...]
   }