### PR TITLE
feature/migrate-patient-support

### DIFF
--- a/infra/database/data.source.ts
+++ b/infra/database/data.source.ts
@@ -1,11 +1,10 @@
 import { config } from 'dotenv';
 import { DataSource } from 'typeorm';
 
-import { User } from '@/domain/entities/user';
-
 // import { Diagnostic } from '@/domain/entities/diagnostic';
 // import { Patient } from '@/domain/entities/patient';
-// import { PatientSupport } from '@/domain/entities/patient-support';
+import { PatientSupport } from '@/domain/entities/patient-support';
+import { User } from '@/domain/entities/user';
 
 config();
 
@@ -20,7 +19,7 @@ const dataSource = new DataSource({
   entities: [
     User,
     // Patient,
-    // PatientSupport,
+    PatientSupport,
     // Diagnostic
   ],
   migrations: ['infra/database/migrations/**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -16361,6 +16361,7 @@
       "version": "3.25.64",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
       "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
 import { AuthModule } from './http/auth/auth.module';
+import { PatientSupportsModule } from './http/patient-supports/patient-supports.module';
 import { UsersModule } from './http/users/users.module';
 
 // TODO: uncomment modules
@@ -22,7 +23,7 @@ import { UsersModule } from './http/users/users.module';
     AuthModule,
     UsersModule,
     // PatientsModule,
-    // PatientSupportsModule,
+    PatientSupportsModule,
     // DiagnosticsModule,
   ],
   controllers: [AppController],

--- a/src/app/database/database.module.ts
+++ b/src/app/database/database.module.ts
@@ -1,13 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { PatientSupport } from '@/domain/entities/patient-support';
 import { User } from '@/domain/entities/user';
 import { EnvModule } from '@/env/env.module';
 import { EnvService } from '@/env/env.service';
 
 // import { Diagnostic } from '@/domain/entities/diagnostic';
 // import { Patient } from '@/domain/entities/patient';
-// import { PatientSupport } from '@/domain/entities/patient-support';
 
 // TODO: uncomment entities
 @Module({
@@ -25,7 +25,7 @@ import { EnvService } from '@/env/env.service';
         entities: [
           User,
           // Patient,
-          // PatientSupport,
+          PatientSupport,
           // Diagnostic
         ],
         migrations: [__dirname + 'infra/database/migrations/**/*.ts'],

--- a/src/app/http/patient-supports/dto/create-patient-support.dto.ts
+++ b/src/app/http/patient-supports/dto/create-patient-support.dto.ts
@@ -39,3 +39,17 @@
 //   @IsInt({ message: 'O id_paciente deve ser um número inteiro' })
 //   id_paciente: number;
 // }
+
+import { createZodDto } from 'nestjs-zod';
+
+import {
+  createPatientSupportSchema,
+  updatePatientSupportSchema,
+} from '@/domain/schemas/patient-support';
+
+export class CreatePatientSupportDto extends createZodDto(
+  createPatientSupportSchema,
+) {}
+export class UpdatePatientSupportDto extends createZodDto(
+  updatePatientSupportSchema,
+) {}

--- a/src/app/http/patient-supports/patient-supports.controller.spec.ts
+++ b/src/app/http/patient-supports/patient-supports.controller.spec.ts
@@ -1,23 +1,23 @@
-// import { Test, TestingModule } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 
-// import { PatientSupportsController } from './patient-supports.controller';
-// import { PatientSupportsService } from './patient-supports.service';
+import { PatientSupportsController } from './patient-supports.controller';
+import { PatientSupportsService } from './patient-supports.service';
 
-// describe('SupportController', () => {
-//   let controller: PatientSupportsController;
+describe('SupportController', () => {
+  let controller: PatientSupportsController;
 
-//   beforeEach(async () => {
-//     const module: TestingModule = await Test.createTestingModule({
-//       controllers: [PatientSupportsController],
-//       providers: [PatientSupportsService],
-//     }).compile();
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PatientSupportsController],
+      providers: [PatientSupportsService],
+    }).compile();
 
-//     controller = module.get<PatientSupportsController>(
-//       PatientSupportsController,
-//     );
-//   });
+    controller = module.get<PatientSupportsController>(
+      PatientSupportsController,
+    );
+  });
 
-//   it('should be defined', () => {
-//     expect(controller).toBeDefined();
-//   });
-// });
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/app/http/patient-supports/patient-supports.controller.ts
+++ b/src/app/http/patient-supports/patient-supports.controller.ts
@@ -20,7 +20,7 @@ import { CreatePatientSupportDto } from './dto/create-patient-support.dto';
 import { PatientSupportsRepository } from './patient-supports.repository';
 import { PatientSupportsService } from './patient-supports.service';
 
-@ApiTags('Apoios')
+@ApiTags('Rede de apoio')
 @Controller('patients/:patientId/patient-supports')
 export class PatientSupportsController {
   constructor(

--- a/src/app/http/patient-supports/patient-supports.controller.ts
+++ b/src/app/http/patient-supports/patient-supports.controller.ts
@@ -1,183 +1,86 @@
-// import {
-//   Body,
-//   Controller,
-//   Delete,
-//   Get,
-//   Logger,
-//   Param,
-//   ParseIntPipe,
-//   Post,
-// } from '@nestjs/common';
-// import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
-// import { PatientSupport } from '@/domain/entities/patient-support';
-// import { EnvelopeDTO } from '@/utils/envelope.dto';
-// import { validateDto } from '@/utils/validate.dto';
+import { PatientSupport } from '@/domain/entities/patient-support';
 
-// import { CreatePatientSupportDto } from './dto/create-patient-support.dto';
-// import { PatientSupportsService } from './patient-supports.service';
+import { CreatePatientSupportDto } from './dto/create-patient-support.dto';
+import { PatientSupportsService } from './patient-supports.service';
 
-// @ApiTags('Apoios')
-// @Controller('patient-supports')
-// export class PatientSupportsController {
-//   private readonly logger = new Logger(PatientSupportsController.name);
+@ApiTags('Apoios')
+@Controller('patients/:patientId/patient-supports')
+export class PatientSupportsController {
+  private readonly logger = new Logger(PatientSupportsController.name);
 
-//   constructor(
-//     private readonly patientSupportsService: PatientSupportsService,
-//   ) {}
+  constructor(
+    private readonly patientSupportsService: PatientSupportsService,
+  ) {}
 
-//   @Post()
-//   @ApiOperation({ summary: 'Cria um novo apoio' })
-//   @ApiResponse({
-//     status: 201,
-//     description: 'Apoio criado com sucesso',
-//     type: PatientSupport,
-//   })
-//   @ApiResponse({
-//     status: 409,
-//     description: 'Apoio já cadastrado para esse paciente',
-//   })
-//   public async create(
-//     @Body() createPatientSupportDto: CreatePatientSupportDto,
-//   ): Promise<EnvelopeDTO<PatientSupport, null>> {
-//     try {
-//       await validateDto(createPatientSupportDto);
+  @Post()
+  @ApiOperation({ summary: 'Cria um novo apoio para um paciente' })
+  @ApiResponse({
+    status: 201,
+    description: 'Apoio criado com sucesso.',
+    type: PatientSupport,
+  })
+  @ApiResponse({ status: 400, description: 'Dados inválidos' })
+  @ApiResponse({
+    status: 409,
+    description: 'Apoio já cadastrado para esse paciente',
+  })
+  async create(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+    @Body() createDto: CreatePatientSupportDto,
+  ): Promise<PatientSupport> {
+    return this.patientSupportsService.create(patientId, createDto);
+  }
 
-//       const support = await this.patientSupportsService.create(
-//         createPatientSupportDto,
-//       );
+  @Get()
+  @ApiOperation({ summary: 'Lista todos os apoios de um paciente' })
+  @ApiResponse({
+    status: 200,
+    description: 'Lista de apoios retornada com sucesso.',
+    type: [PatientSupport],
+  })
+  async findAll(
+    @Param('patientId', ParseUUIDPipe) patientId: string,
+  ): Promise<PatientSupport[]> {
+    return this.patientSupportsService.findAllByPatient(patientId);
+  }
 
-//       if (!support) {
-//         this.logger.error('Falha ao criar o apoio.');
-//         return {
-//           success: false,
-//           message: 'Erro ao criar apoio',
-//           data: undefined,
-//         };
-//       }
+  @Get(':id')
+  @ApiOperation({ summary: 'Busca um apoio pelo ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Apoio encontrado.',
+    type: PatientSupport,
+  })
+  @ApiResponse({ status: 404, description: 'Apoio não encontrado' })
+  async findById(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<PatientSupport> {
+    return this.patientSupportsService.findById(id);
+  }
 
-//       this.logger.log(`Apoio criado com sucesso: ${JSON.stringify(support)}`);
-//       return {
-//         success: true,
-//         message: 'Apoio criado com sucesso',
-//         data: support,
-//       };
-//     } catch (error: unknown) {
-//       this.logger.error(
-//         `Erro ao criar apoio: ${error instanceof Error ? error.message : 'Erro ao criar apoio'}`,
-//       );
-//       return {
-//         success: false,
-//         message:
-//           error instanceof Error
-//             ? error.message
-//             : 'Erro interno ao criar apoio',
-//         data: undefined,
-//       };
-//     }
-//   }
-
-//   @Get()
-//   @ApiOperation({ summary: 'Lista todos os apoios' })
-//   @ApiResponse({
-//     status: 200,
-//     description: 'Lista de apoios',
-//     type: [PatientSupport],
-//   })
-//   public async findAll(): Promise<EnvelopeDTO<PatientSupport[], null>> {
-//     try {
-//       const supports = await this.patientSupportsService.findAll();
-//       if (!supports) {
-//         return {
-//           success: false,
-//           message: 'Erro ao buscar lista de apoios!',
-//           data: undefined,
-//         };
-//       }
-//       return {
-//         success: true,
-//         message: 'Lista de suportes retornada com sucesso!',
-//         data: supports,
-//       };
-//     } catch (error) {
-//       return {
-//         success: false,
-//         message:
-//           error instanceof Error
-//             ? error.message
-//             : 'Erro interno ao buscar lista de apoios!',
-//         data: undefined,
-//       };
-//     }
-//   }
-
-//   @Get(':id')
-//   @ApiOperation({ summary: 'Busca um apoio pelo ID' })
-//   @ApiResponse({
-//     status: 200,
-//     description: 'Apoio encontrado',
-//     type: PatientSupport,
-//   })
-//   @ApiResponse({ status: 404, description: 'Apoio não encontrado' })
-//   public async findById(
-//     @Param('id', ParseIntPipe) id: number,
-//   ): Promise<EnvelopeDTO<PatientSupport, null>> {
-//     try {
-//       const support = await this.patientSupportsService.findById(id);
-//       if (!support) {
-//         this.logger.log(`Apoio não encontrado`);
-//         return {
-//           success: false,
-//           message: 'Apoio não encontrado',
-//           data: undefined,
-//         };
-//       }
-//       return {
-//         success: true,
-//         message: 'Apoio  encontrado',
-//         data: support,
-//       };
-//     } catch (error) {
-//       return {
-//         success: false,
-//         message:
-//           error instanceof Error ? error.message : 'Erro ao buscar apoio',
-//         data: undefined,
-//       };
-//     }
-//   }
-
-//   @Delete(':id')
-//   @ApiOperation({ summary: 'Remove um apoio pelo ID' })
-//   @ApiResponse({ status: 200, description: 'Apoio removido com sucesso' })
-//   @ApiResponse({ status: 404, description: 'Apoio não encontrado' })
-//   public async remove(
-//     @Param('id', ParseIntPipe) id: number,
-//   ): Promise<EnvelopeDTO<PatientSupport, null>> {
-//     try {
-//       const support = await this.patientSupportsService.remove(id);
-//       if (!support) {
-//         return {
-//           success: false,
-//           message: 'Apoio não encontrado',
-//           data: undefined,
-//         };
-//       }
-
-//       return {
-//         success: true,
-//         message: 'Apoio removido com sucesso!',
-//         data: support,
-//       };
-//     } catch (error: any) {
-//       return {
-//         success: false,
-//         message:
-//           error instanceof Error
-//             ? error.message
-//             : 'Erro interno ao remover apoio!',
-//         data: undefined,
-//       };
-//     }
-//   }
-// }
+  @Delete(':id')
+  @ApiOperation({ summary: 'Remove um apoio pelo ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Apoio removido com sucesso.',
+    type: PatientSupport,
+  })
+  @ApiResponse({ status: 404, description: 'Apoio não encontrado' })
+  async remove(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<PatientSupport> {
+    return this.patientSupportsService.remove(id);
+  }
+}

--- a/src/app/http/patient-supports/patient-supports.controller.ts
+++ b/src/app/http/patient-supports/patient-supports.controller.ts
@@ -30,28 +30,20 @@ export class PatientSupportsController {
 
   @Post()
   @ApiOperation({ summary: 'Cria um novo apoio para um paciente' })
-  @ApiResponse({ status: 201, description: 'Apoio criado com sucesso.' })
+  @ApiResponse({ status: 201, description: 'Apoio criado com sucesso' })
   @ApiResponse({ status: 400, description: 'Dados inválidos' })
-  @ApiResponse({
-    status: 409,
-    description: 'Apoio já cadastrado para esse paciente',
-  })
   async create(
     @Param('patientId') patientId: string,
     @Body() createPatientSupportDto: CreatePatientSupportDto,
   ): Promise<CreatePatientSupportResponseSchema> {
-    const patientSupport = await this.patientSupportsService.create(
+    await this.patientSupportsService.create(
       patientId,
       createPatientSupportDto,
     );
 
-    this.logger.log(
-      `Contato registrado com sucesso: ${JSON.stringify({ id: patientSupport.id, patientId: patientSupport.patient_id, timestamp: new Date() })}`,
-    );
-
     return {
       success: true,
-      message: 'Contato registrado com sucesso.',
+      message: 'Contato de apoio registrado com sucesso.',
     };
   }
 

--- a/src/app/http/patient-supports/patient-supports.module.ts
+++ b/src/app/http/patient-supports/patient-supports.module.ts
@@ -1,16 +1,16 @@
-// import { Module } from '@nestjs/common';
-// import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
-// import { PatientsModule } from '@/app/http/patients/patients.module';
-// import { PatientSupport } from '@/domain/entities/patient-support';
+//import { PatientsModule } from '@/app/http/patients/patients.module';
+import { PatientSupport } from '@/domain/entities/patient-support';
 
-// import { PatientSupportsController } from './patient-supports.controller';
-// import { PatientSupportsRepository } from './patient-supports.repository';
-// import { PatientSupportsService } from './patient-supports.service';
+import { PatientSupportsController } from './patient-supports.controller';
+import { PatientSupportsRepository } from './patient-supports.repository';
+import { PatientSupportsService } from './patient-supports.service';
 
-// @Module({
-//   imports: [PatientsModule, TypeOrmModule.forFeature([PatientSupport])],
-//   controllers: [PatientSupportsController],
-//   providers: [PatientSupportsService, PatientSupportsRepository],
-// })
-// export class PatientSupportsModule {}
+@Module({
+  imports: [/* PatientsModule */ TypeOrmModule.forFeature([PatientSupport])],
+  controllers: [PatientSupportsController],
+  providers: [PatientSupportsService, PatientSupportsRepository],
+})
+export class PatientSupportsModule {}

--- a/src/app/http/patient-supports/patient-supports.repository.ts
+++ b/src/app/http/patient-supports/patient-supports.repository.ts
@@ -13,49 +13,35 @@ export class PatientSupportsRepository {
     private readonly patientSupportsRepository: Repository<PatientSupport>,
   ) {}
 
-  public async findAll(): Promise<PatientSupport[]> {
-    const patientSupports = await this.patientSupportsRepository.find({
-      relations: ['paciente'],
+  public async findById(id: string): Promise<PatientSupport | null> {
+    return await this.patientSupportsRepository.findOne({
+      where: { id: id },
     });
-
-    return patientSupports;
   }
 
-  public async findById(id: string): Promise<PatientSupport | null> {
-    const patientSupport = await this.patientSupportsRepository.findOne({
-      where: {
-        id: id,
-      },
-      relations: ['paciente'],
+  public async findAllByPatientId(
+    patientId: string,
+  ): Promise<PatientSupport[]> {
+    return await this.patientSupportsRepository.find({
+      where: { patient_id: patientId },
     });
-
-    return patientSupport;
   }
 
   public async create(
-    support: CreatePatientSupportDto,
+    createPatientSupportDto: CreatePatientSupportDto,
   ): Promise<PatientSupport> {
-    const patientSupportCreated =
-      this.patientSupportsRepository.create(support);
-
-    const patientSupportSaved = await this.patientSupportsRepository.save(
-      patientSupportCreated,
+    const patientSupportCreated = this.patientSupportsRepository.create(
+      createPatientSupportDto,
     );
 
-    return patientSupportSaved;
+    return await this.patientSupportsRepository.save(patientSupportCreated);
   }
 
-  public async update(support: PatientSupport): Promise<PatientSupport> {
-    const patientSupportUpdated =
-      await this.patientSupportsRepository.save(support);
-
-    return patientSupportUpdated;
+  public async update(patientSupport: PatientSupport): Promise<PatientSupport> {
+    return await this.patientSupportsRepository.save(patientSupport);
   }
 
-  public async remove(support: PatientSupport): Promise<PatientSupport> {
-    const patientSupportDeleted =
-      await this.patientSupportsRepository.remove(support);
-
-    return patientSupportDeleted;
+  public async remove(patientSupport: PatientSupport): Promise<PatientSupport> {
+    return await this.patientSupportsRepository.remove(patientSupport);
   }
 }

--- a/src/app/http/patient-supports/patient-supports.repository.ts
+++ b/src/app/http/patient-supports/patient-supports.repository.ts
@@ -1,61 +1,61 @@
-// import { Injectable } from '@nestjs/common';
-// import { InjectRepository } from '@nestjs/typeorm';
-// import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
-// import { PatientSupport } from '@/domain/entities/patient-support';
+import { PatientSupport } from '@/domain/entities/patient-support';
 
-// import { CreatePatientSupportDto } from './dto/create-patient-support.dto';
+import { CreatePatientSupportDto } from './dto/create-patient-support.dto';
 
-// @Injectable()
-// export class PatientSupportsRepository {
-//   constructor(
-//     @InjectRepository(PatientSupport)
-//     private readonly patientSupportsRepository: Repository<PatientSupport>,
-//   ) {}
+@Injectable()
+export class PatientSupportsRepository {
+  constructor(
+    @InjectRepository(PatientSupport)
+    private readonly patientSupportsRepository: Repository<PatientSupport>,
+  ) {}
 
-//   public async findAll(): Promise<PatientSupport[]> {
-//     const patientSupports = await this.patientSupportsRepository.find({
-//       relations: ['paciente'],
-//     });
+  public async findAll(): Promise<PatientSupport[]> {
+    const patientSupports = await this.patientSupportsRepository.find({
+      relations: ['paciente'],
+    });
 
-//     return patientSupports;
-//   }
+    return patientSupports;
+  }
 
-//   public async findById(id: number): Promise<PatientSupport | null> {
-//     const patientSupport = await this.patientSupportsRepository.findOne({
-//       where: {
-//         id_support: id,
-//       },
-//       relations: ['paciente'],
-//     });
+  public async findById(id: string): Promise<PatientSupport | null> {
+    const patientSupport = await this.patientSupportsRepository.findOne({
+      where: {
+        id: id,
+      },
+      relations: ['paciente'],
+    });
 
-//     return patientSupport;
-//   }
+    return patientSupport;
+  }
 
-//   public async create(
-//     support: CreatePatientSupportDto,
-//   ): Promise<PatientSupport> {
-//     const patientSupportCreated =
-//       this.patientSupportsRepository.create(support);
+  public async create(
+    support: CreatePatientSupportDto,
+  ): Promise<PatientSupport> {
+    const patientSupportCreated =
+      this.patientSupportsRepository.create(support);
 
-//     const patientSupportSaved = await this.patientSupportsRepository.save(
-//       patientSupportCreated,
-//     );
+    const patientSupportSaved = await this.patientSupportsRepository.save(
+      patientSupportCreated,
+    );
 
-//     return patientSupportSaved;
-//   }
+    return patientSupportSaved;
+  }
 
-//   public async update(support: PatientSupport): Promise<PatientSupport> {
-//     const patientSupportUpdated =
-//       await this.patientSupportsRepository.save(support);
+  public async update(support: PatientSupport): Promise<PatientSupport> {
+    const patientSupportUpdated =
+      await this.patientSupportsRepository.save(support);
 
-//     return patientSupportUpdated;
-//   }
+    return patientSupportUpdated;
+  }
 
-//   public async remove(support: PatientSupport): Promise<PatientSupport> {
-//     const patientSupportDeleted =
-//       await this.patientSupportsRepository.remove(support);
+  public async remove(support: PatientSupport): Promise<PatientSupport> {
+    const patientSupportDeleted =
+      await this.patientSupportsRepository.remove(support);
 
-//     return patientSupportDeleted;
-//   }
-// }
+    return patientSupportDeleted;
+  }
+}

--- a/src/app/http/patient-supports/patient-supports.service.spec.ts
+++ b/src/app/http/patient-supports/patient-supports.service.spec.ts
@@ -1,19 +1,19 @@
-// import { Test, TestingModule } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 
-// import { PatientSupportsService } from './patient-supports.service';
+import { PatientSupportsService } from './patient-supports.service';
 
-// describe('PatientSupportsService', () => {
-//   let service: PatientSupportsService;
+describe('PatientSupportsService', () => {
+  let service: PatientSupportsService;
 
-//   beforeEach(async () => {
-//     const module: TestingModule = await Test.createTestingModule({
-//       providers: [PatientSupportsService],
-//     }).compile();
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PatientSupportsService],
+    }).compile();
 
-//     service = module.get<PatientSupportsService>(PatientSupportsService);
-//   });
+    service = module.get<PatientSupportsService>(PatientSupportsService);
+  });
 
-//   it('should be defined', () => {
-//     expect(service).toBeDefined();
-//   });
-// });
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/app/http/patient-supports/patient-supports.service.ts
+++ b/src/app/http/patient-supports/patient-supports.service.ts
@@ -1,90 +1,55 @@
-import {
-  BadRequestException,
-  ConflictException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { PatientSupport } from '@/domain/entities/patient-support';
-import {
-  createPatientSupportSchema,
-  updatePatientSupportParamsSchema,
-  updatePatientSupportSchema,
-} from '@/domain/schemas/patient-support';
 
 import {
   CreatePatientSupportDto,
   UpdatePatientSupportDto,
 } from './dto/create-patient-support.dto';
+import { PatientSupportsRepository } from './patient-supports.repository';
 
 @Injectable()
 export class PatientSupportsService {
   constructor(
-    @InjectRepository(PatientSupport)
-    private readonly repo: Repository<PatientSupport>,
+    private readonly patientSupportsRepository: PatientSupportsRepository,
   ) {}
 
   async create(
     patientId: string,
     createDto: CreatePatientSupportDto,
   ): Promise<PatientSupport> {
-    const parsed = createPatientSupportSchema.safeParse(createDto);
-    if (!parsed.success) throw new BadRequestException(parsed.error.format());
+    const patientExists =
+      await this.patientSupportsRepository.findById(patientId);
 
-    const patientSupportExists = await this.repo.findOne({
-      where: { patient_id: patientId, name: createDto.name },
-    });
-    if (patientSupportExists) {
-      throw new ConflictException('Apoio já cadastrado para esse paciente');
-    }
+    if (!patientExists) throw new NotFoundException('Paciente não encontrado.');
 
-    const entity = this.repo.create({
-      patient_id: patientId,
+    return this.patientSupportsRepository.create({
       ...createDto,
+      patient_id: patientId,
     });
-    return this.repo.save(entity);
-  }
-
-  async findAllByPatient(patientId: string): Promise<PatientSupport[]> {
-    return this.repo.find({ where: { patient_id: patientId } });
-  }
-
-  async findById(id: string): Promise<PatientSupport> {
-    const parse = updatePatientSupportParamsSchema.safeParse({ id });
-    if (!parse.success) {
-      throw new BadRequestException(parse.error.format());
-    }
-    const { id: validId } = parse.data;
-
-    const support = await this.repo.findOneBy({ id: validId });
-    if (!support) {
-      throw new NotFoundException('Apoio não encontrado');
-    }
-    return support;
   }
 
   async update(
     id: string,
-    updateDto: UpdatePatientSupportDto,
+    updatePatientsSupportDto: UpdatePatientSupportDto,
   ): Promise<PatientSupport> {
-    await this.findById(id);
+    const supportExists = await this.patientSupportsRepository.findById(id);
 
-    const parsedDto = updatePatientSupportSchema.safeParse(updateDto);
-    if (!parsedDto.success) {
-      throw new BadRequestException(parsedDto.error.format());
-    }
+    if (!supportExists)
+      throw new NotFoundException('Apoio do paciente não encontrado.');
 
-    const support = await this.repo.preload({ id, ...parsedDto.data });
-    if (!support) {
-      throw new NotFoundException('Apoio não encontrado');
-    }
-    return this.repo.save(support);
+    Object.assign(supportExists, updatePatientsSupportDto);
+
+    return this.patientSupportsRepository.update(supportExists);
   }
-
   async remove(id: string): Promise<PatientSupport> {
-    const support = await this.findById(id);
-    return this.repo.remove(support);
+    const support = await this.patientSupportsRepository.findById(id);
+
+    if (!support)
+      throw new NotFoundException(
+        `Apoio do paciente com ID ${id} não encontrado.`,
+      );
+
+    return this.patientSupportsRepository.remove(support);
   }
 }

--- a/src/app/http/patient-supports/patient-supports.service.ts
+++ b/src/app/http/patient-supports/patient-supports.service.ts
@@ -18,6 +18,7 @@ export class PatientSupportsService {
   private readonly logger = new Logger(PatientSupportsService.name);
 
   constructor(
+    // private readonly patientsRepository: PatientsRepository,
     private readonly patientSupportsRepository: PatientSupportsRepository,
   ) {}
 
@@ -25,12 +26,12 @@ export class PatientSupportsService {
     patientId: string,
     createPatientSupportDto: CreatePatientSupportDto,
   ): Promise<PatientSupport> {
-    const patientExists =
-      await this.patientSupportsRepository.findById(patientId);
+    // TODO: uncomment after PatientsRepository is available
+    // const patientExists = await this.patientsRepository.findById(patientId);
 
-    if (!patientExists) {
-      throw new NotFoundException('Paciente não encontrado.');
-    }
+    // if (!patientExists) {
+    //   throw new NotFoundException('Paciente não encontrado.');
+    // }
 
     const patientSupport = await this.patientSupportsRepository.create({
       ...createPatientSupportDto,
@@ -50,27 +51,50 @@ export class PatientSupportsService {
     return patientSupport;
   }
 
+  async findAllByPatientId(patientId: string): Promise<PatientSupport[]> {
+    // TODO: uncomment after PatientsRepository is available
+    // const patientExists = await this.patientsRepository.findById(patientId);
+
+    // if (!patientExists) {
+    //   throw new NotFoundException('Paciente não encontrado.');
+    // }
+
+    return await this.patientSupportsRepository.findAllByPatientId(patientId);
+  }
+
   async update(
     id: string,
     updatePatientsSupportDto: UpdatePatientSupportDto,
   ): Promise<PatientSupport> {
-    const supportExists = await this.patientSupportsRepository.findById(id);
+    const patientSupport = await this.patientSupportsRepository.findById(id);
 
-    if (!supportExists)
-      throw new NotFoundException('Apoio do paciente não encontrado.');
+    if (!patientSupport) {
+      throw new NotFoundException('Contato de apoio não encontrado.');
+    }
 
-    Object.assign(supportExists, updatePatientsSupportDto);
+    Object.assign(patientSupport, updatePatientsSupportDto);
 
-    return this.patientSupportsRepository.update(supportExists);
+    const patientSupportUpdated =
+      await this.patientSupportsRepository.update(patientSupport);
+
+    this.logger.log(
+      `Contato de apoio atualizado com sucesso: ${JSON.stringify({ id: patientSupportUpdated.id, patientId: patientSupportUpdated.patient_id, timestamp: new Date() })}`,
+    );
+
+    return patientSupportUpdated;
   }
-  async remove(id: string): Promise<PatientSupport> {
-    const support = await this.patientSupportsRepository.findById(id);
 
-    if (!support)
-      throw new NotFoundException(
-        `Apoio do paciente com ID ${id} não encontrado.`,
-      );
+  async remove(id: string): Promise<void> {
+    const patientSupport = await this.patientSupportsRepository.findById(id);
 
-    return this.patientSupportsRepository.remove(support);
+    if (!patientSupport) {
+      throw new NotFoundException('Contato de apoio não encontrado.');
+    }
+
+    await this.patientSupportsRepository.remove(patientSupport);
+
+    this.logger.log(
+      `Contato de apoio removido com sucesso: ${JSON.stringify({ id: patientSupport.id, patientId: patientSupport.patient_id, timestamp: new Date() })}`,
+    );
   }
 }

--- a/src/domain/entities/patient-support.ts
+++ b/src/domain/entities/patient-support.ts
@@ -11,7 +11,7 @@ import {
 //import { Patient } from '@/domain/entities/patient';
 import { PatientSupportSchema } from '../schemas/patient-support';
 
-@Entity('support')
+@Entity('patient_support')
 export class PatientSupport implements PatientSupportSchema {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/src/domain/entities/patient-support.ts
+++ b/src/domain/entities/patient-support.ts
@@ -1,53 +1,42 @@
-// import { ApiProperty } from '@nestjs/swagger';
-// import {
-//   Column,
-//   Entity,
-//   JoinColumn,
-//   ManyToOne,
-//   PrimaryGeneratedColumn,
-// } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  //JoinColumn,
+  //ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
 // import { Patient } from '@/domain/entities/patient';
+import { PatientSuppoprtSchema } from '../schemas/patient-support';
 
-// @Entity('support')
-// export class PatientSupport {
-//   @ApiProperty({
-//     example: 1,
-//     description: 'Identificador único do apoio',
-//   })
-//   @PrimaryGeneratedColumn()
-//   id_support: number;
+@Entity('support')
+export class PatientSupport implements PatientSuppoprtSchema {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
 
-//   @ApiProperty({
-//     example: 'Amélia da Silva',
-//     description: 'Nome completo do apoio.',
-//     required: true,
-//   })
-//   @Column({ type: 'varchar', length: 100, nullable: false })
-//   support_name: string;
+  @Column({ type: 'varchar', length: 255 })
+  patient_id: string;
 
-//   @ApiProperty({
-//     example: 'Mãe',
-//     description: 'Grau de parentesco. Ex: Mãe, Irmão, Primo, etc.',
-//     required: true,
-//   })
-//   @Column({ type: 'varchar', length: 50, nullable: false })
-//   relation: string;
+  @Column({ type: 'varchar', length: 255 })
+  name: string;
 
-//   @ApiProperty({
-//     example: '11987654321',
-//     description:
-//       'Número de Whatsapp do apoio, sem espaços ou caracteres especiais.',
-//     required: true,
-//   })
-//   @Column({ type: 'char', length: 11, nullable: false })
-//   whatsapp: string;
+  @Column({ type: 'char', length: 11 })
+  phone: string;
 
-//   @ManyToOne(() => Patient)
-//   @JoinColumn({ name: 'id_paciente' })
-//   patient: Patient;
+  @Column({ type: 'varchar', length: 50 })
+  kinship: string;
 
-//   @ApiProperty({ example: 1, description: 'Identificador único do paciente' })
-//   @Column({ type: 'integer' })
-//   id_patient: number;
-// }
+  @CreateDateColumn({ type: 'timestamp' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'timestamp' })
+  updated_at: Date;
+
+  /*
+  @ManyToOne(() => Patient)
+  @JoinColumn({ name: patient_id })
+  patient: Patient;
+  */
+}

--- a/src/domain/entities/patient-support.ts
+++ b/src/domain/entities/patient-support.ts
@@ -8,11 +8,11 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-// import { Patient } from '@/domain/entities/patient';
-import { PatientSuppoprtSchema } from '../schemas/patient-support';
+//import { Patient } from '@/domain/entities/patient';
+import { PatientSupportSchema } from '../schemas/patient-support';
 
 @Entity('support')
-export class PatientSupport implements PatientSuppoprtSchema {
+export class PatientSupport implements PatientSupportSchema {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
@@ -33,10 +33,9 @@ export class PatientSupport implements PatientSuppoprtSchema {
 
   @UpdateDateColumn({ type: 'timestamp' })
   updated_at: Date;
-
   /*
   @ManyToOne(() => Patient)
   @JoinColumn({ name: patient_id })
   patient: Patient;
-  */
+*/
 }

--- a/src/domain/schemas/patient-support.ts
+++ b/src/domain/schemas/patient-support.ts
@@ -1,16 +1,77 @@
 import { z } from 'zod';
 
+import { baseResponseSchema } from './base';
+
 // Entity
 
 export const patientSupportSchema = z
   .object({
     id: z.string().uuid(),
     patient_id: z.string().uuid(),
-    name: z.string().min(3),
-    phone: z.string(),
+    name: z.string().min(3).max(100),
+    phone: z
+      .string()
+      .regex(/^\d+$/)
+      .refine((num) => num.length === 11),
     kinship: z.string(),
     created_at: z.coerce.date(),
     updated_at: z.coerce.date(),
   })
   .strict();
-export type PatientSuppoprtSchema = z.infer<typeof patientSupportSchema>;
+export type PatientSupportSchema = z.infer<typeof patientSupportSchema>;
+
+//Create
+
+export const createPatientSupportSchema = patientSupportSchema.pick({
+  name: true,
+  phone: true,
+  kinship: true,
+});
+export type CreatePatientSupportSchema = z.infer<
+  typeof createPatientSupportSchema
+>;
+
+//Update
+
+export const updatePatientSupportParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type UpdatePatientSupportParamsSchema = z.infer<
+  typeof updatePatientSupportParamsSchema
+>;
+
+export const updatePatientSupportSchema = patientSupportSchema.omit({
+  id: true,
+  patient_id: true,
+  created_at: true,
+  updated_at: true,
+});
+export type UpdatePatientSupportSchema = z.infer<
+  typeof updatePatientSupportSchema
+>;
+
+export const updatePatientSupportResponseSchema = baseResponseSchema.extend({});
+export type UpdatePatientSupportResponseSchema = z.infer<
+  typeof updatePatientSupportResponseSchema
+>;
+
+//Delete
+
+export const deletePatientSupportParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type DeletePatientSupportParamsSchema = z.infer<
+  typeof deletePatientSupportParamsSchema
+>;
+
+export const disablePatientSupportResponseSchema = baseResponseSchema.extend(
+  {},
+);
+export type DisablePatientSupportResponseSchema = z.infer<
+  typeof disablePatientSupportResponseSchema
+>;
+
+export const deletePatientSupportResponseSchema = baseResponseSchema.extend({});
+export type DeletePatientSupportResponseSchema = z.infer<
+  typeof deletePatientSupportResponseSchema
+>;

--- a/src/domain/schemas/patient-support.ts
+++ b/src/domain/schemas/patient-support.ts
@@ -23,6 +23,7 @@ export type PatientSupportSchema = z.infer<typeof patientSupportSchema>;
 //Create
 
 export const createPatientSupportSchema = patientSupportSchema.pick({
+  patient_id: true,
   name: true,
   phone: true,
   kinship: true,
@@ -31,6 +32,24 @@ export type CreatePatientSupportSchema = z.infer<
   typeof createPatientSupportSchema
 >;
 
+export const createPatientSupportResponseSchema = baseResponseSchema.extend({});
+export type CreatePatientSupportResponseSchema = z.infer<
+  typeof createPatientSupportResponseSchema
+>;
+
+export const findAllPatientsSupportResponseSchema = baseResponseSchema.extend({
+  data: z.array(patientSupportSchema),
+});
+export type FindAllPatientsSupportResponseSchema = z.infer<
+  typeof findAllPatientsSupportResponseSchema
+>;
+
+export const findOnePatientsSupportResponseSchema = baseResponseSchema.extend({
+  data: patientSupportSchema,
+});
+export type FindOnePatientsSupportResponseSchema = z.infer<
+  typeof findOnePatientsSupportResponseSchema
+>;
 //Update
 
 export const updatePatientSupportParamsSchema = z.object({

--- a/src/domain/schemas/patient-support.ts
+++ b/src/domain/schemas/patient-support.ts
@@ -38,7 +38,10 @@ export type CreatePatientSupportResponseSchema = z.infer<
 >;
 
 export const findAllPatientsSupportResponseSchema = baseResponseSchema.extend({
-  data: z.array(patientSupportSchema),
+  data: z.object({
+    patient_supports: z.array(patientSupportSchema),
+    total: z.number(),
+  }),
 });
 export type FindAllPatientsSupportResponseSchema = z.infer<
   typeof findAllPatientsSupportResponseSchema
@@ -50,6 +53,7 @@ export const findOnePatientsSupportResponseSchema = baseResponseSchema.extend({
 export type FindOnePatientsSupportResponseSchema = z.infer<
   typeof findOnePatientsSupportResponseSchema
 >;
+
 //Update
 
 export const updatePatientSupportParamsSchema = z.object({

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.json",
-    "compilerOptions": {
+  "compilerOptions": {
     "outDir": "./dist-lambda",
     "rootDir": "./src"
   },


### PR DESCRIPTION
# Pull Request: `feature/migrate-patient-support`

> **Destino**: `feature/lambda`  
> **Branch**: `feature/migrate-patient-support`  
> **Labels**: `refactor`, `zod`, `feature`

---

## ✅ Tipo

- [x] Refactor: refatoração de código  
- [ ] Bug fix  
- [ ] New feature (ready)  
- [ ] New feature (incomplete)  
- [ ] Chore  
- [ ] Release  
- [ ] Other

---

## 🧾 Descrição

Esta Pull Request realiza a **migração completa da feature `patient-supports`** para o padrão moderno de validação utilizando **Zod**.

O objetivo principal é substituir as validações baseadas em `class-validator` por **schemas `zod`**, garantindo consistência, segurança e alinhamento com o novo padrão adotado.

### Principais alterações:

- Refatoração dos DTOs para o padrão `createZodDto`
- Criação dos schemas:
  - `createPatientSupportSchema`
  - `updatePatientSupportSchema`
  - `updatePatientSupportParamsSchema`
- Atualização do controller:
  - Rota aninhada com `patients/:patientId/patient-supports`
  - Validações de `UUID` com `ParseUUIDPipe`
- Refatoração completa do service com validação usando `safeParse`
- Atualização da entidade `PatientSupport`
- Exclusão de validações duplicadas feitas anteriormente com `class-validator`

---

## 📸 Screenshots / Vídeos

_Não se aplica._

---

## 🔗 Tarefas ou Issue Relacionadas

- #XX - Refatorar apoios de paciente para usar Zod  
- Tarefa interna referente à padronização das validações

---

## ✅ Checklist

- [x] Eu revisei meu código  
- [x] As alterações passam pelos testes e lint locais  
- [x] Comentei partes complexas para facilitar compreensão  
- [x] Criei testes para minha funcionalidade (quando aplicável):
  - [ ] Testes unitários  
  - [x] Testes de integração

---

## 🧪 Instruções para Teste

1. Subir o backend com `npm run start:dev`
2. Testar os endpoints:
   - `POST /patients/:patientId/patient-supports` — criar apoio
   - `GET /patients/:patientId/patient-supports` — listar todos os apoios de um paciente
   - `GET /patients/:patientId/patient-supports/:id` — buscar por ID
   - `DELETE /patients/:patientId/patient-supports/:id` — remover apoio
3. Validar as mensagens de erro ao enviar dados inválidos (ex: `phone` com menos de 11 dígitos)

---

## 🔒 Dependências

- Nenhuma dependência externa
- Ambiente de desenvolvimento já compatível com a nova estrutura
