### PR TITLE
Feature/patient inactivation endpoint

### DIFF
--- a/src/app/http/patients/patients.controller.ts
+++ b/src/app/http/patients/patients.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   NotFoundException,
   Param,
+  Patch,
   Post,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
@@ -14,6 +15,7 @@ import {
   DeletePatientResponseSchema,
   FindAllPatientsResponseSchema,
   FindOnePatientResponseSchema,
+  InactivatePatientResponseSchema,
 } from '@/domain/schemas/patient';
 
 import { CreatePatientDto } from './patients.dtos';
@@ -120,5 +122,21 @@ export class PatientsController {
         data: [],
       };
     }
+  }
+
+  @Patch(':id/inactivate')
+  @ApiOperation({ summary: 'Inativa o Paciente pelo ID' })
+  @ApiResponse({ status: 200, description: 'Paciente inativado com sucesso' })
+  @ApiResponse({ status: 404, description: 'Paciente não encontrado' })
+  @ApiResponse({ status: 409, description: 'Paciente já está inativo' })
+  async inactivatePatient(
+    @Param('id') id: string,
+  ): Promise<InactivatePatientResponseSchema> {
+    await this.patientsService.deactivatePatient(id);
+
+    return {
+      success: true,
+      message: 'Paciente inativado com sucesso.',
+    };
   }
 }

--- a/src/app/http/patients/patients.repository.ts
+++ b/src/app/http/patients/patients.repository.ts
@@ -109,4 +109,11 @@ export class PatientsRepository {
       relations: ['user'], // Adicione outras relações conforme necessário
     });
   }
+
+  public async setPatientInactive(id: string): Promise<Patient> {
+    return this.patientsRepository.save({
+      id,
+      status: 'inactive',
+    });
+  }
 }

--- a/src/app/http/patients/patients.repository.ts
+++ b/src/app/http/patients/patients.repository.ts
@@ -110,10 +110,7 @@ export class PatientsRepository {
     });
   }
 
-  public async setPatientInactive(id: string): Promise<Patient> {
-    return this.patientsRepository.save({
-      id,
-      status: 'inactive',
-    });
+  public async deactivate(id: string): Promise<Patient> {
+    return this.patientsRepository.save({ id, status: 'inactive' });
   }
 }

--- a/src/app/http/patients/patients.service.ts
+++ b/src/app/http/patients/patients.service.ts
@@ -89,14 +89,14 @@ export class PatientsService {
     const patient = await this.patientsRepository.findById(id);
 
     if (!patient) {
-      throw new NotFoundException('Paciente não encontrado!');
+      throw new NotFoundException('Paciente não encontrado.');
     }
 
     if (patient.status == 'inactive') {
       throw new ConflictException('Paciente já está inativo.');
     }
 
-    await this.patientsRepository.setPatientInactive(id);
+    await this.patientsRepository.deactivate(id);
 
     this.logger.log(
       `Paciente inativado com sucesso: ${JSON.stringify({ id: patient.id, userId: patient.user_id, timestamp: new Date() })}`,

--- a/src/app/http/patients/patients.service.ts
+++ b/src/app/http/patients/patients.service.ts
@@ -84,4 +84,22 @@ export class PatientsService {
       };
     });
   }
+
+  async deactivatePatient(id: string): Promise<void> {
+    const patient = await this.patientsRepository.findById(id);
+
+    if (!patient) {
+      throw new NotFoundException('Paciente não encontrado!');
+    }
+
+    if (patient.status == 'inactive') {
+      throw new ConflictException('Paciente já está inativo.');
+    }
+
+    await this.patientsRepository.setPatientInactive(id);
+
+    this.logger.log(
+      `Paciente inativado com sucesso: ${JSON.stringify({ id: patient.id, userId: patient.user_id, timestamp: new Date() })}`,
+    );
+  }
 }

--- a/src/domain/entities/patient.ts
+++ b/src/domain/entities/patient.ts
@@ -13,7 +13,13 @@ import {
 // import { PatientSupport } from '@/domain/entities/patient-support';
 import { User } from '@/domain/entities/user';
 
-import { GENDERS, GenderType, PatientSchema } from '../schemas/patient';
+import {
+  GENDERS,
+  GenderType,
+  PatientSchema,
+  STATUS,
+  StatusType,
+} from '../schemas/patient';
 import { PatientSupport } from './patient-support';
 
 @Entity('patients')
@@ -59,6 +65,9 @@ export class Patient implements PatientSchema {
 
   @Column({ type: 'tinyint', width: 1, default: 0 })
   has_nmo_diagnosis: boolean;
+
+  @Column({ type: 'enum', enum: STATUS })
+  status: StatusType;
 
   @CreateDateColumn({ type: 'timestamp' })
   created_at: Date;

--- a/src/domain/schemas/patient.ts
+++ b/src/domain/schemas/patient.ts
@@ -14,6 +14,9 @@ export const GENDERS = [
 ] as const;
 export type GenderType = (typeof GENDERS)[number];
 
+export const STATUS = ['active', 'inactive'] as const;
+export type StatusType = (typeof STATUS)[number];
+
 export const patientSchema = z
   .object({
     id: z.string().uuid(),
@@ -34,6 +37,7 @@ export const patientSchema = z
     take_medication: z.boolean().default(false),
     medication_desc: z.string().nullable(),
     has_nmo_diagnosis: z.boolean().default(false),
+    status: z.enum(STATUS).default('active'),
     created_at: z.coerce.date(),
     updated_at: z.coerce.date(),
   })
@@ -72,4 +76,9 @@ export type FindOnePatientResponseSchema = z.infer<
 export const deletePatientResponseSchema = baseResponseSchema.extend({});
 export type DeletePatientResponseSchema = z.infer<
   typeof deletePatientResponseSchema
+>;
+
+export const inactivatePatientResponseSchema = baseResponseSchema.extend({});
+export type InactivatePatientResponseSchema = z.infer<
+  typeof inactivatePatientResponseSchema
 >;


### PR DESCRIPTION
## ✅  Tipo
- [x] New feature (incomplete): adição de nova funcionalidade, porém incompleta

## 🧾 Descrição

Esta Pull Request adiciona um novo endpoint chamado /patients/:id/inactivate para inativar o paciente pelo seu ID.

Ao passar o id do paciente nos parâmetros do endpoint, o campo do paciente 'status' é colocado como 'inactive'.

### Principais alterações:

- Criação do endpoint PATCH  /patients/:id/inactivate
- Criação do método deactivatePatient() na service para verificação e retorno de Log na inativação do paciente
- Implementação do método setPatientInactive() no repository para mudança no status do paciente
- Adicionado o campo enum 'status' para Entidade Paciente

## Checklist

- [x] Eu revisei meu código
- [x] As alterações passam pelos testes e lint locais
- [x] Criei testes para minha funcionalidade (quando aplicável):
  - [x] Testes de integração
  
## 🧪 Instruções para Teste

1. Subir o backend com `npm run start:dev`
2. Gerar a migration com ` npm run db:generate <nome da migration>`
3. Fazer as alterações no banco de dados com a migration com `npm run db:migrate`
4. Testar o endpoint:
   - **PATCH** `/patients/:id/inactivate`  
     Inativa o paciente
   - Validações:
     - Testar mensagem de erro com id inválido
     - Testar mensagem de erro com id de paciente já inativo


## Tarefas ou Issue
- [ #113 [Backend] Migrar endpoint para inativar paciente ](https://tree.taiga.io/project/ipecode-abnmo/task/113)