### PR TITLE
feat: adiciona script de seed para ambiente de desenvolvimento

### DIFF
--- a/infra/database/seed-dev.ts
+++ b/infra/database/seed-dev.ts
@@ -1,0 +1,125 @@
+import 'reflect-metadata';
+
+import { faker } from '@faker-js/faker';
+
+import { Patient } from '../../src/domain/entities/patient';
+import { PatientSupport } from '../../src/domain/entities/patient-support';
+import { User } from '../../src/domain/entities/user';
+import dataSource from './data.source';
+
+const DATABASE_DEV_NAME = 'abnmo_db';
+
+async function main() {
+  try {
+    await dataSource.initialize();
+    const dbName = dataSource.options.database;
+
+    if (dbName !== DATABASE_DEV_NAME) {
+      console.log(
+        `❌ Execução negada. O banco atual não é o de desenvolvimento (${DATABASE_DEV_NAME})`,
+      );
+      process.exit(1);
+    }
+
+    console.log('🧹 Limpando banco de dados...');
+    await dataSource.query('SET FOREIGN_KEY_CHECKS = 0');
+    await dataSource.manager.clear(PatientSupport);
+    await dataSource.manager.clear(Patient);
+    await dataSource.manager.clear(User);
+    await dataSource.query('SET FOREIGN_KEY_CHECKS = 1');
+
+    console.log('✅ Dados antigos apagados.');
+
+    console.log('📦 Executando migrations...');
+    await dataSource.runMigrations();
+    console.log('✅ Migrations executadas.');
+
+    const userRepository = dataSource.getRepository(User);
+    const patientRepository = dataSource.getRepository(Patient);
+    const supportRepository = dataSource.getRepository(PatientSupport);
+
+    const roles = ['admin', 'nurse', 'specialist', 'manager'] as const;
+
+    console.log('👤 Criando usuários de sistema...');
+    for (const role of roles) {
+      const user = userRepository.create({
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+        role,
+        avatar_url: faker.image.avatar(),
+      });
+
+      await userRepository.save(user);
+      console.log(`✅ Usuário ${role} criado: ${user.email}`);
+    }
+
+    console.log('🧑‍⚕️ Criando 50 pacientes...');
+    for (let i = 0; i < 50; i++) {
+      const user = userRepository.create({
+        name: faker.person.fullName(),
+        email: faker.internet.email(),
+        password: faker.internet.password(),
+        role: 'patient',
+        avatar_url: faker.image.avatar(),
+      });
+
+      await userRepository.save(user);
+
+      const patient = patientRepository.create({
+        user,
+        gender: faker.helpers.arrayElement([
+          'male_cis',
+          'female_cis',
+          'male_trans',
+          'female_trans',
+          'non_binary',
+          'prefer_not_to_say',
+        ]),
+        date_of_birth: faker.date.birthdate({ min: 18, max: 80, mode: 'age' }),
+        phone: faker.string.numeric(11),
+        cpf: faker.string.numeric(11),
+        state: 'PE',
+        city: faker.location.city(),
+        has_disability: faker.datatype.boolean(),
+        disability_desc: faker.lorem.sentence(),
+        need_legal_assistance: faker.datatype.boolean(),
+        take_medication: faker.datatype.boolean(),
+        medication_desc: faker.lorem.sentence(),
+        has_nmo_diagnosis: faker.datatype.boolean(),
+        status: 'active',
+      });
+
+      await patientRepository.save(patient);
+
+      const supportCount = faker.number.int({ min: 0, max: 3 });
+      for (let j = 0; j < supportCount; j++) {
+        const support = supportRepository.create({
+          patient: patient,
+          name: faker.person.fullName(),
+          phone: faker.string.numeric(11),
+          kinship: faker.helpers.arrayElement([
+            'pai',
+            'mãe',
+            'irmão',
+            'cônjuge',
+          ]),
+        });
+
+        await supportRepository.save(support);
+      }
+
+      console.log(
+        `✅ Paciente ${i + 1} criado com ${supportCount} contato(s) de apoio`,
+      );
+    }
+
+    console.log('🎉 Seed finalizado com sucesso.');
+    process.exit(0);
+  } catch (err) {
+    console.error('❌ Erro ao executar seed:', err);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-lambda": "^3.806.0",
         "@aws-sdk/client-ses": "3.856.0",
+        "@faker-js/faker": "9.9.0",
         "@nestjs/class-validator": "^0.13.1",
         "@nestjs/common": "^11.0.1",
         "@nestjs/config": "^4.0.0",
@@ -75,7 +76,7 @@
         "ts-jest": "^29.3.1",
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
-        "tsconfig-paths": "^4.2.0",
+        "tsconfig-paths": "4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
       }
@@ -2538,6 +2539,22 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -5045,7 +5062,7 @@
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.18.tgz",
       "integrity": "sha512-ORZxyCKKiqYt2iHdh1C7pfVR1GBjkuFOdwqZggQzaq0vt22DpGca+2JsUtkUoWQmWcct04v5+ScwgvsHuMObxA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5087,6 +5104,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5100,14 +5118,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.21",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
       "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "services:wait:database": "ts-node ./infra/scripts/wait-for-database.ts",
     "db:generate": "ts-node ./infra/scripts/generate-migration.ts",
     "db:migrate": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js -d ./infra/database/data.source.ts migration:run",
+    "db:seed-dev": "ts-node -r tsconfig-paths/register infra/database/seed-dev.ts",
     "lint:eslint:check": "eslint .",
     "lint:prettier:check": "prettier --check .",
     "lint:prettier:fix": "prettier --write . --log-level=warn",
@@ -34,6 +35,7 @@
   "dependencies": {
     "@aws-sdk/client-lambda": "^3.806.0",
     "@aws-sdk/client-ses": "3.856.0",
+    "@faker-js/faker": "9.9.0",
     "@nestjs/class-validator": "^0.13.1",
     "@nestjs/common": "^11.0.1",
     "@nestjs/config": "^4.0.0",
@@ -98,7 +100,7 @@
     "ts-jest": "^29.3.1",
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
-    "tsconfig-paths": "^4.2.0",
+    "tsconfig-paths": "4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
   },


### PR DESCRIPTION
Esta PR adiciona um script (`seed-dev.ts`) que:
- Limpa o banco de dados (tabelas `users`, `patients`, `patient_support`)
- Executa as migrations
- Popula o banco com dados fictícios usando a lib `faker`
- Cria usuários de todos os cargos e 50 pacientes com contatos de apoio
