### PR TITLE
feat: add reset password endpoint

### DIFF
--- a/src/app/http/auth/auth.controller.ts
+++ b/src/app/http/auth/auth.controller.ts
@@ -15,7 +15,7 @@ import type { SignInWithEmailResponseSchema } from '@/domain/schemas/auth';
 import { UtilsService } from '@/utils/utils.service';
 
 import { CreateUserDto } from '../users/users.dtos';
-import { SignInWithEmailDto } from './auth.dtos';
+import { ResetPasswordDto, SignInWithEmailDto } from './auth.dtos';
 import { AuthService } from './auth.service';
 
 @Public()
@@ -80,6 +80,34 @@ export class AuthController {
     return {
       success: true,
       message: 'Logout realizado com sucesso.',
+    };
+  }
+
+  @Post('reset-password')
+  async resetPassword(
+    @Res({ passthrough: true }) response: Response,
+    @Cookies(COOKIES_MAPPER.password_reset as 'password_reset')
+    passwordResetToken: string,
+    @Body() resetPasswordDto: ResetPasswordDto,
+  ) {
+    if (!passwordResetToken) {
+      throw new UnauthorizedException('Token de redefinição de senha ausente');
+    }
+
+    const { accessToken } = await this.authService.resetPassword(
+      passwordResetToken,
+      resetPasswordDto.password,
+    );
+
+    this.utilsService.setCookie(response, {
+      name: COOKIES_MAPPER.access_token,
+      value: accessToken,
+      maxAge: 1000 * 60 * 60 * 12,
+    });
+
+    return {
+      success: true,
+      message: 'Senha atualizada com sucesso',
     };
   }
 }

--- a/src/app/http/auth/auth.dtos.ts
+++ b/src/app/http/auth/auth.dtos.ts
@@ -1,8 +1,13 @@
 import { createZodDto } from 'nestjs-zod';
 
-import { signInWithEmailSchema } from '@/domain/schemas/auth';
+import {
+  resetPasswordSchema,
+  signInWithEmailSchema,
+} from '@/domain/schemas/auth';
 import { createAuthTokenSchema } from '@/domain/schemas/token';
 
 export class SignInWithEmailDto extends createZodDto(signInWithEmailSchema) {}
 
 export class CreateAuthTokenDto extends createZodDto(createAuthTokenSchema) {}
+
+export class ResetPasswordDto extends createZodDto(resetPasswordSchema) {}

--- a/src/app/http/users/users.repository.ts
+++ b/src/app/http/users/users.repository.ts
@@ -43,4 +43,8 @@ export class UsersRepository {
   public async remove(user: User): Promise<User> {
     return await this.usersRepository.remove(user);
   }
+
+  public async updatePassword(id: string, hashedPassword: string) {
+    await this.usersRepository.update(id, { password: hashedPassword });
+  }
 }

--- a/src/domain/schemas/auth.ts
+++ b/src/domain/schemas/auth.ts
@@ -9,6 +9,11 @@ export const signInWithEmailSchema = z.object({
 });
 export type SignInWithEmailSchema = z.infer<typeof signInWithEmailSchema>;
 
+export const resetPasswordSchema = z.object({
+  password: z.string().min(8).max(255),
+});
+export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>;
+
 export const signInWithEmailResponseSchema = baseResponseSchema.extend({});
 export type SignInWithEmailResponseSchema = z.infer<
   typeof signInWithEmailResponseSchema


### PR DESCRIPTION
## Descrição da PR

Esta PR adiciona o endpoint `POST /reset-password` para permitir que usuários redefinam suas senhas de forma segura.

## Mudanças Implementadas

- **Novo endpoint**: `POST /reset-password`
  - Recebe a nova senha no corpo da requisição: `{ password: "string" }`
  - Verifica a presença do token `password_reset` nos cookies assinados
  - Valida o token no banco de dados
  - Atualiza a senha do usuário
  - Realiza login automático e retorna novo token de acesso

- **Alterações no banco de dados**:
  - Utiliza a tabela existente `tokens` com o tipo `password_reset`

- **Segurança**:
  - Tokens de reset são válidos apenas uma vez
  - Verificação de expiração do token