### PR TITLE
Refactor signature webhook to always return 200

### DIFF
--- a/src/app/http/webhooks/webhooks.controller.ts
+++ b/src/app/http/webhooks/webhooks.controller.ts
@@ -7,6 +7,7 @@ import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
 import { BaseResponse } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
+import { LogService } from '@/common/log/log.service';
 import type { RequestUser } from '@/common/types';
 
 import { CreateWebhookEventUseCase } from './use-cases/create-webhook-event.use-case';
@@ -28,6 +29,7 @@ export class WebhooksController {
     private readonly getWebhookEventsUseCase: GetWebhookEventsUseCase,
     private readonly getWebhookEventUseCase: GetWebhookEventUseCase,
     private readonly createWebhookEventUseCase: CreateWebhookEventUseCase,
+    private readonly logger: LogService,
   ) {}
 
   @Get('/events')
@@ -70,9 +72,18 @@ export class WebhooksController {
   @ApiOperation({ summary: 'Recebe webhooks de assinatura do ClickSign' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async surveySignature(
-    @Req() req: Request,
+    @Req() req: Request & { webhookValid?: boolean },
     @Body() body: SurveySignatureWebhookBody,
   ): Promise<BaseResponse> {
+    if (!req.webhookValid) {
+      this.logger.warn('Invalid signature webhook received');
+
+      return {
+        success: true,
+        message: 'Webhook de assinatura recebido com sucesso.',
+      };
+    }
+
     const fullBody = req.body as unknown as Record<string, unknown>;
 
     const webhookEvent = await this.createWebhookEventUseCase.execute({

--- a/src/common/middlewares/signature.middleware.ts
+++ b/src/common/middlewares/signature.middleware.ts
@@ -1,10 +1,6 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
-import {
-  Injectable,
-  NestMiddleware,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { Injectable, NestMiddleware } from '@nestjs/common';
 import { NextFunction, Request, Response } from 'express';
 
 import { EnvService } from '@/env/env.service';
@@ -17,19 +13,21 @@ export class SignatureMiddleware implements NestMiddleware {
     this.secret = this.envService.get('CLICKSIGN_WEBHOOK_SECRET');
   }
 
-  use(req: Request & { rawBody?: Buffer }, _res: Response, next: NextFunction) {
+  use(
+    req: Request & { rawBody?: Buffer; webhookValid?: boolean },
+    _res: Response,
+    next: NextFunction,
+  ) {
     const hmacHeader = req.headers['content-hmac'] as string | undefined;
 
     if (!hmacHeader) {
-      throw new UnauthorizedException(
-        'Assinatura HMAC não encontrada no cabeçalho.',
-      );
+      req.webhookValid = false;
+      return next();
     }
 
     if (!req.rawBody) {
-      throw new UnauthorizedException(
-        'Corpo da requisição não disponível para validação.',
-      );
+      req.webhookValid = false;
+      return next();
     }
 
     const received = hmacHeader.replace(/^sha256=/, '');
@@ -45,9 +43,11 @@ export class SignatureMiddleware implements NestMiddleware {
         Buffer.from(computed, 'hex'),
       )
     ) {
-      throw new UnauthorizedException('Assinatura HMAC inválida.');
+      req.webhookValid = false;
+      return next();
     }
 
+    req.webhookValid = true;
     next();
   }
 }

--- a/tests/e2e/webhooks.e2e-spec.ts
+++ b/tests/e2e/webhooks.e2e-spec.ts
@@ -44,17 +44,17 @@ describe('Webhooks – Signature (e2e)', () => {
   });
 
   describe('POST /webhooks/signatures/survey', () => {
-    it('returns 401 when content-hmac header is missing', async () => {
+    it('returns 200 when content-hmac header is missing', async () => {
       const res = await api.post('/webhooks/signatures/survey', makePayload());
 
-      expect(res.status).toBe(401);
-      expect(res.body.success).toBe(false);
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
       expect(res.body.message).toBe(
-        'Assinatura HMAC não encontrada no cabeçalho.',
+        'Webhook de assinatura recebido com sucesso.',
       );
     });
 
-    it('returns 401 when HMAC is invalid', async () => {
+    it('returns 200 when HMAC is invalid', async () => {
       const res = await api.post('/webhooks/signatures/survey', makePayload(), {
         headers: {
           'content-hmac':
@@ -62,9 +62,11 @@ describe('Webhooks – Signature (e2e)', () => {
         },
       });
 
-      expect(res.status).toBe(401);
-      expect(res.body.success).toBe(false);
-      expect(res.body.message).toBe('Assinatura HMAC inválida.');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toBe(
+        'Webhook de assinatura recebido com sucesso.',
+      );
     });
 
     it('bypasses when metadata key does not match', async () => {

--- a/tests/unit/middlewares/signature.middleware.spec.ts
+++ b/tests/unit/middlewares/signature.middleware.spec.ts
@@ -1,6 +1,5 @@
 import { createHmac } from 'node:crypto';
 
-import { UnauthorizedException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 
@@ -33,30 +32,30 @@ describe('SignatureMiddleware', () => {
     return `sha256=${createHmac('sha256', SECRET).update(payload).digest('hex')}`;
   };
 
-  it('throws if content-hmac header is missing', () => {
+  it('sets "webhookValid=false" and calls next when content-hmac header is missing', () => {
     const req = { headers: {}, rawBody } as any;
     const next = jest.fn();
 
-    expect(() => middleware.use(req, {} as any, next)).toThrow(
-      UnauthorizedException,
-    );
-    expect(next).not.toHaveBeenCalled();
+    middleware.use(req, {} as any, next);
+
+    expect(req.webhookValid).toBe(false);
+    expect(next).toHaveBeenCalled();
   });
 
-  it('throws if rawBody is missing', () => {
+  it('sets "webhookValid=false" and calls next when rawBody is missing', () => {
     const req = {
       headers: { 'content-hmac': makeValidHmac(body) },
       rawBody: undefined,
     } as any;
     const next = jest.fn();
 
-    expect(() => middleware.use(req, {} as any, next)).toThrow(
-      UnauthorizedException,
-    );
-    expect(next).not.toHaveBeenCalled();
+    middleware.use(req, {} as any, next);
+
+    expect(req.webhookValid).toBe(false);
+    expect(next).toHaveBeenCalled();
   });
 
-  it('throws if HMAC does not match', () => {
+  it('sets "webhookValid=false" and calls next when HMAC does not match', () => {
     const req = {
       headers: {
         'content-hmac':
@@ -66,13 +65,13 @@ describe('SignatureMiddleware', () => {
     } as any;
     const next = jest.fn();
 
-    expect(() => middleware.use(req, {} as any, next)).toThrow(
-      UnauthorizedException,
-    );
-    expect(next).not.toHaveBeenCalled();
+    middleware.use(req, {} as any, next);
+
+    expect(req.webhookValid).toBe(false);
+    expect(next).toHaveBeenCalled();
   });
 
-  it('calls next when HMAC is valid', () => {
+  it('sets "webhookValid=true" and calls next when HMAC is valid', () => {
     const req = {
       headers: { 'content-hmac': makeValidHmac(body) },
       rawBody,
@@ -81,6 +80,7 @@ describe('SignatureMiddleware', () => {
 
     middleware.use(req, {} as any, next);
 
+    expect(req.webhookValid).toBe(true);
     expect(next).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Resumo
O middleware de assinatura agora define um booleano `webhookValid` no request em vez de lançar 401, e o controller sempre responde 200 — processa o payload apenas quando o HMAC é válido.

## Objetivo
Evitar que o ClickSign reenvie webhooks desnecessariamente. Antes, requisições com HMAC ausente ou inválido recebiam 401, fazendo o ClickSign tentar novamente.

## Principais mudanças
- `SignatureMiddleware`: define `req.webhookValid` (true/false) e sempre chama `next()`, sem lançar exceções
- `WebhooksController.surveySignature()`: persiste e processa o payload apenas quando `webhookValid === true`; webhooks inválidos são logados com `LogService.warn()` e retornam 200 sem processamento
- Testes unitários e e2e atualizados para validar o novo comportamento

## Informações adicionais
Nenhuma.
