### PR TITLE
Add signature health check to `GET /status`

### DIFF
--- a/src/app/http/status/status.module.ts
+++ b/src/app/http/status/status.module.ts
@@ -1,9 +1,12 @@
 import { Module } from '@nestjs/common';
 
+import { SignatureModule } from '@/app/signature/signature.module';
+
 import { StatusController } from './status.controller';
 import { GetStatusUseCase } from './use-cases/get-status.use-case';
 
 @Module({
+  imports: [SignatureModule],
   controllers: [StatusController],
   providers: [GetStatusUseCase],
 })

--- a/src/app/http/status/use-cases/get-status.use-case.ts
+++ b/src/app/http/status/use-cases/get-status.use-case.ts
@@ -41,10 +41,14 @@ export class GetStatusUseCase {
       const signatureOk = await this.signatureService.check();
 
       if (!signatureOk) {
+        success = false;
+        message = 'O serviço de assinatura está indisponível.';
         data.signature.status = 'error';
         this.logger.error('Signature health check failed');
       }
     } catch {
+      success = false;
+      message = 'O serviço de assinatura está indisponível.';
       data.signature.status = 'error';
       this.logger.error('Signature health check failed');
     }

--- a/src/app/http/status/use-cases/get-status.use-case.ts
+++ b/src/app/http/status/use-cases/get-status.use-case.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
 
+import { SignatureService } from '@/app/signature/signature.service';
 import { Log } from '@/common/log/log.decorator';
 import { LogService } from '@/common/log/log.service';
 
@@ -13,6 +14,7 @@ export class GetStatusUseCase {
   constructor(
     @InjectDataSource()
     private readonly dataSource: DataSource,
+    private readonly signatureService: SignatureService,
     private readonly logger: LogService,
   ) {}
 
@@ -23,6 +25,7 @@ export class GetStatusUseCase {
     const data: GetStatusResponse['data'] = {
       api: { status: 'ok' },
       database: { status: 'ok' },
+      signature: { status: 'ok' },
     };
 
     try {
@@ -32,6 +35,18 @@ export class GetStatusUseCase {
       message = 'O banco de dados está indisponível.';
       data.database.status = 'error';
       this.logger.error('Database health check failed');
+    }
+
+    try {
+      const signatureOk = await this.signatureService.check();
+
+      if (!signatureOk) {
+        data.signature.status = 'error';
+        this.logger.error('Signature health check failed');
+      }
+    } catch {
+      data.signature.status = 'error';
+      this.logger.error('Signature health check failed');
     }
 
     return { success, message, data };

--- a/src/app/signature/signature.module.ts
+++ b/src/app/signature/signature.module.ts
@@ -13,6 +13,10 @@ import { SendReminderSignatureUseCase } from './use-cases/send-reminder-signatur
     RequestSignatureUseCase,
     SendReminderSignatureUseCase,
   ],
-  exports: [RequestSignatureUseCase, SendReminderSignatureUseCase],
+  exports: [
+    RequestSignatureUseCase,
+    SendReminderSignatureUseCase,
+    SignatureService,
+  ],
 })
 export class SignatureModule {}

--- a/src/app/signature/signature.service.ts
+++ b/src/app/signature/signature.service.ts
@@ -21,6 +21,23 @@ export class SignatureService {
     this.apiKey = this.envService.get('CLICKSIGN_API_KEY');
   }
 
+  async check(): Promise<boolean> {
+    try {
+      const url = new URL('envelopes?per_page=1', this.apiUrl);
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: this.apiKey,
+          Accept: 'application/vnd.api+json',
+        },
+      });
+
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
   async api<T = unknown>(
     path: string,
     options: ApiOptions,

--- a/src/app/signature/signature.service.ts
+++ b/src/app/signature/signature.service.ts
@@ -15,13 +15,19 @@ interface ApiResponse<T = unknown> {
 export class SignatureService {
   private readonly apiUrl: string;
   private readonly apiKey: string;
+  private readonly enabled: boolean;
 
   constructor(private readonly envService: EnvService) {
     this.apiUrl = this.envService.get('CLICKSIGN_API_URL');
     this.apiKey = this.envService.get('CLICKSIGN_API_KEY');
+    this.enabled = this.envService.get('SIGNATURE_ENABLED');
   }
 
   async check(): Promise<boolean> {
+    if (!this.enabled) {
+      return true;
+    }
+
     try {
       const url = new URL('envelopes?per_page=1', this.apiUrl);
 

--- a/src/common/http-exception.filter.ts
+++ b/src/common/http-exception.filter.ts
@@ -116,16 +116,18 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
         message = responseMessage;
       }
 
-      // TODO: make this block more readable
-      if (
+      const isNotFoundRoute =
+        exception instanceof HttpException &&
         status === HttpStatus.NOT_FOUND &&
-        responseMessage &&
+        typeof responseMessage === 'string' &&
         /^Cannot (GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS) \//.test(
           responseMessage,
-        )
-      ) {
+        );
+
+      if (isNotFoundRoute) {
         status = HttpStatus.FORBIDDEN;
         message = 'Você não tem permissão para executar esta ação.';
+        return response.status(status).json({ success: false, message });
       }
 
       this.logger.error('HttpException', {

--- a/src/domain/schemas/status/responses.ts
+++ b/src/domain/schemas/status/responses.ts
@@ -8,5 +8,6 @@ export const getStatusResponseSchema = baseResponseSchema.extend({
   data: z.object({
     api: z.object({ status: statusSchema }),
     database: z.object({ status: statusSchema }),
+    signature: z.object({ status: statusSchema }),
   }),
 });

--- a/tests/e2e/status.e2e-spec.ts
+++ b/tests/e2e/status.e2e-spec.ts
@@ -22,5 +22,6 @@ describe('Status (e2e)', () => {
     expect(res.body.message).toBe('Sistema está operacional.');
     expect(res.body.data.api.status).toBe('ok');
     expect(res.body.data.database.status).toBe('ok');
+    expect(res.body.data.signature.status).toBe('ok');
   });
 });

--- a/tests/unit/use-cases/status/get-status.use-case.spec.ts
+++ b/tests/unit/use-cases/status/get-status.use-case.spec.ts
@@ -4,20 +4,26 @@ import { mock, MockProxy } from 'jest-mock-extended';
 import { DataSource } from 'typeorm';
 
 import { GetStatusUseCase } from '@/app/http/status/use-cases/get-status.use-case';
+import { SignatureService } from '@/app/signature/signature.service';
 import { LogService } from '@/common/log/log.service';
 
 describe('GetStatusUseCase', () => {
   let useCase: GetStatusUseCase;
   let dataSource: MockProxy<DataSource>;
+  let signatureService: MockProxy<SignatureService>;
+  let logger: { log: jest.Mock; error: jest.Mock };
 
   beforeEach(async () => {
     dataSource = mock<DataSource>();
+    signatureService = mock<SignatureService>();
+    logger = { log: jest.fn(), error: jest.fn() };
 
     const module = await Test.createTestingModule({
       providers: [
         GetStatusUseCase,
         { provide: getDataSourceToken(), useValue: dataSource },
-        { provide: LogService, useValue: { log: jest.fn(), error: jest.fn() } },
+        { provide: SignatureService, useValue: signatureService },
+        { provide: LogService, useValue: logger },
       ],
     }).compile();
 
@@ -25,8 +31,9 @@ describe('GetStatusUseCase', () => {
   });
 
   describe('Success', () => {
-    it('returns ok when DB is healthy', async () => {
+    it('returns ok when DB and signature are healthy', async () => {
       dataSource.query.mockResolvedValue([{ 1: 1 }]);
+      signatureService.check.mockResolvedValue(true);
 
       const result = await useCase.execute();
 
@@ -36,6 +43,7 @@ describe('GetStatusUseCase', () => {
         data: {
           api: { status: 'ok' },
           database: { status: 'ok' },
+          signature: { status: 'ok' },
         },
       });
       expect(dataSource.query).toHaveBeenCalledWith('SELECT 1');
@@ -45,6 +53,7 @@ describe('GetStatusUseCase', () => {
   describe('Error', () => {
     it('returns error when DB query fails', async () => {
       dataSource.query.mockRejectedValue(new Error('Connection refused'));
+      signatureService.check.mockResolvedValue(true);
 
       const result = await useCase.execute();
 
@@ -54,6 +63,58 @@ describe('GetStatusUseCase', () => {
         data: {
           api: { status: 'ok' },
           database: { status: 'error' },
+          signature: { status: 'ok' },
+        },
+      });
+    });
+
+    it('returns signature error when check returns false', async () => {
+      dataSource.query.mockResolvedValue([{ 1: 1 }]);
+      signatureService.check.mockResolvedValue(false);
+
+      const result = await useCase.execute();
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Sistema está operacional.',
+        data: {
+          api: { status: 'ok' },
+          database: { status: 'ok' },
+          signature: { status: 'error' },
+        },
+      });
+    });
+
+    it('returns signature error when check throws', async () => {
+      dataSource.query.mockResolvedValue([{ 1: 1 }]);
+      signatureService.check.mockRejectedValue(new Error('Network error'));
+
+      const result = await useCase.execute();
+
+      expect(result).toEqual({
+        success: true,
+        message: 'Sistema está operacional.',
+        data: {
+          api: { status: 'ok' },
+          database: { status: 'ok' },
+          signature: { status: 'error' },
+        },
+      });
+    });
+
+    it('returns errors for both DB and signature', async () => {
+      dataSource.query.mockRejectedValue(new Error('Connection refused'));
+      signatureService.check.mockRejectedValue(new Error('Network error'));
+
+      const result = await useCase.execute();
+
+      expect(result).toEqual({
+        success: false,
+        message: 'O banco de dados está indisponível.',
+        data: {
+          api: { status: 'ok' },
+          database: { status: 'error' },
+          signature: { status: 'error' },
         },
       });
     });

--- a/tests/unit/use-cases/status/get-status.use-case.spec.ts
+++ b/tests/unit/use-cases/status/get-status.use-case.spec.ts
@@ -75,8 +75,8 @@ describe('GetStatusUseCase', () => {
       const result = await useCase.execute();
 
       expect(result).toEqual({
-        success: true,
-        message: 'Sistema está operacional.',
+        success: false,
+        message: 'O serviço de assinatura está indisponível.',
         data: {
           api: { status: 'ok' },
           database: { status: 'ok' },
@@ -92,8 +92,8 @@ describe('GetStatusUseCase', () => {
       const result = await useCase.execute();
 
       expect(result).toEqual({
-        success: true,
-        message: 'Sistema está operacional.',
+        success: false,
+        message: 'O serviço de assinatura está indisponível.',
         data: {
           api: { status: 'ok' },
           database: { status: 'ok' },
@@ -110,7 +110,7 @@ describe('GetStatusUseCase', () => {
 
       expect(result).toEqual({
         success: false,
-        message: 'O banco de dados está indisponível.',
+        message: 'O serviço de assinatura está indisponível.',
         data: {
           api: { status: 'ok' },
           database: { status: 'error' },


### PR DESCRIPTION
## Resumo
Adiciona verificação de conectividade com a API ClickSign ao endpoint `GET /status`, reportando `signature: { status: "ok" | "error" }` na resposta. Também silencia logs de erro para rotas inexistentes (ex: `/favicon.ico`).

## Objetivo
Permitir monitoramento proativo da integração com ClickSign. O `GET /status` já verificava API e banco de dados; agora também verifica se a chave de API ClickSign é válida e o serviço está acessível.

## Principais mudanças
- `SignatureService.check()` — faz um `GET /api/v3/envelopes?per_page=1` com a chave de API para verificar conectividade
- `GetStatusUseCase` — injeta `SignatureService` e reporta `signature: { status }` no campo `data`
- `StatusModule` — importa `SignatureModule`
- Schema `getStatusResponseSchema` — novo campo `signature: { status: "ok" | "error" }`
- `HttpExceptionFilter` — não loga mais erros de rotas não encontradas (404 → 403), evitando ruído de `/favicon.ico`
- Testes unitários cobrem 4 cenários de assinatura: ok, false, throws, e ambos db+signature com erro

## Informações adicionais
Nenhuma.
