### PR TITLE
Add Sentry error monitoring and log forwarding

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -36,7 +36,7 @@ CLICKSIGN_WEBHOOK_SECRET=clicksign-webhook-secret
 
 # Observability
 SENTRY_DSN=
-SENTRY_ENABLE_LOGS=false
+SENTRY_LOGS=none
 
 # Database
 DB_HOST=database

--- a/.env.docker
+++ b/.env.docker
@@ -34,6 +34,10 @@ CLICKSIGN_API_URL=http://localhost
 CLICKSIGN_API_KEY=clicksign-api-key
 CLICKSIGN_WEBHOOK_SECRET=clicksign-webhook-secret
 
+# Observability
+SENTRY_DSN=
+SENTRY_ENABLE_LOGS=false
+
 # Database
 DB_HOST=database
 DB_PORT=5432

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ CLICKSIGN_API_URL="http://localhost"
 CLICKSIGN_API_KEY="clicksign-api-key"
 CLICKSIGN_WEBHOOK_SECRET="clicksign-webhook-secret"
 
+# Observability
+SENTRY_DSN=""
+SENTRY_ENABLE_LOGS="false"
+
 # Database
 DB_HOST="localhost"
 DB_PORT=3306

--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ CLICKSIGN_WEBHOOK_SECRET="clicksign-webhook-secret"
 
 # Observability
 SENTRY_DSN=""
-SENTRY_ENABLE_LOGS="false"
+SENTRY_LOGS="none"
 
 # Database
 DB_HOST="localhost"

--- a/.env.test
+++ b/.env.test
@@ -34,6 +34,10 @@ CLICKSIGN_API_URL="http://localhost"
 CLICKSIGN_API_KEY="clicksign-api-key"
 CLICKSIGN_WEBHOOK_SECRET="clicksign-webhook-secret"
 
+# Observability
+SENTRY_DSN=""
+SENTRY_ENABLE_LOGS="false"
+
 # Database
 DB_HOST="localhost"
 DB_PORT=5432

--- a/.env.test
+++ b/.env.test
@@ -36,7 +36,7 @@ CLICKSIGN_WEBHOOK_SECRET="clicksign-webhook-secret"
 
 # Observability
 SENTRY_DSN=""
-SENTRY_ENABLE_LOGS="false"
+SENTRY_LOGS="none"
 
 # Database
 DB_HOST="localhost"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "abnmo-backend",
+  "name": "abnmo-svm-backend",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "abnmo-backend",
+      "name": "abnmo-svm-backend",
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
@@ -23,6 +23,7 @@
         "@nestjs/platform-express": "11.1.28",
         "@nestjs/swagger": "11.4.6",
         "@nestjs/typeorm": "11.0.1",
+        "@sentry/nestjs": "10.68.0",
         "@types/aws-serverless-express": "3.3.10",
         "@vendia/serverless-express": "4.12.6",
         "archiver": "7.0.1",
@@ -211,6 +212,67 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz",
+      "integrity": "sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3554,10 +3616,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "devOptional": true,
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -4377,6 +4438,119 @@
         "npm": ">=5.10.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -4422,6 +4596,141 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.68.0.tgz",
+      "integrity": "sha512-5Amhx8ltVz7vb1bRGyf3c4J69/iHW8R/H+SJxTRILHlsSOBrnVVc/IQEYDC6PTRdRdZ3x2u7RVjxZi2Mhe525g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/nestjs": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nestjs/-/nestjs-10.68.0.tgz",
+      "integrity": "sha512-xzuDztTa13f2XscFVpIYB7mF6o4immmw9rnzSyHQZYCQiBNpfnSPdZ422hoW7/u1/HI57nWjAB0+z7fcdSnHVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node": "10.68.0",
+        "@sentry/server-utils": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.68.0.tgz",
+      "integrity": "sha512-bnvRzEehquG/894DD3BWNCBUbDWsLQfYPU+SNCMd6G4Ext75RthVkRs8R0sRaE6b8Tw9HSEgySHL834Tf8lVsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/node-core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
+        "@sentry/server-utils": "10.68.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.68.0.tgz",
+      "integrity": "sha512-VreORXnruy8A2SyprZKENAq3ArGwn35KPewLQSQ5dgDXSFtUj2scLuzZoVsZ/Uyt83td0WPvD6Lv0X7MvSYAMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "@sentry/opentelemetry": "10.68.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.68.0.tgz",
+      "integrity": "sha512-JDNH9dacX0MSi7FRvabPCJUAXRMTe16bE/Gajc/7Gfcw7Rwvo4DZ0nd162PCSAW9QoEjUT12upDehEHJuFmsXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.68.0.tgz",
+      "integrity": "sha512-lp1ZSs1auw7HrCESSYt/n4dOUaKPVUIAKyVYRk6xVr4bMIN3RPub/H5Wm7QPj9CpXVC5bQFvB6+dHZXz809oMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "0.7.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.68.0",
+        "meriyah": "^6.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -5120,7 +5429,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -6721,6 +7029,15 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -8614,10 +8931,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -8942,10 +9258,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -8971,7 +9286,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -10229,6 +10543,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
+      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -12196,6 +12530,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -12336,6 +12679,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -13655,6 +14004,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/resend": {
       "version": "6.17.2",
       "resolved": "https://registry.npmjs.org/resend/-/resend-6.17.2.tgz",
@@ -13943,6 +14305,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.7.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@nestjs/platform-express": "11.1.28",
     "@nestjs/swagger": "11.4.6",
     "@nestjs/typeorm": "11.0.1",
+    "@sentry/nestjs": "10.68.0",
     "@types/aws-serverless-express": "3.3.10",
     "@vendia/serverless-express": "4.12.6",
     "archiver": "7.0.1",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
+import { SentryModule } from '@sentry/nestjs/setup';
 import { LoggerModule } from 'nestjs-pino';
 import { ZodSerializerInterceptor } from 'nestjs-zod';
 
@@ -45,6 +46,7 @@ import { StorageModule } from './storage/storage.module';
       envFilePath: process.env.NODE_ENV === 'test' ? '.env.test' : '.env',
       validate: (env) => envSchema.parse(env),
     }),
+    SentryModule.forRoot(),
     EnvModule,
     LoggerModule.forRootAsync({
       imports: [EnvModule],

--- a/src/app/http/auth/use-cases/expire-session.use-case.ts
+++ b/src/app/http/auth/use-cases/expire-session.use-case.ts
@@ -28,7 +28,7 @@ export class ExpireSessionUseCase {
   }: ExpireSessionUseCaseInput): Promise<void> {
     if (!tokenHash && !userId) {
       this.logger.log(
-        'Expire session skipped: no <tokenHash> and <userId> provided',
+        'Expire session skipped – no tokenHash or userId provided',
       );
       return;
     }
@@ -45,7 +45,7 @@ export class ExpireSessionUseCase {
     });
 
     this.logger.log(
-      `Session expired by <${tokenHash ? 'tokenHash' : 'userId'}>`,
+      `Session expired by ${tokenHash ? 'tokenHash' : 'userId'}`,
       { logout },
     );
   }

--- a/src/app/lambda.ts
+++ b/src/app/lambda.ts
@@ -1,3 +1,4 @@
+import '../instrument.js';
 import 'reflect-metadata';
 
 import type { RequestListener } from 'node:http';

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,3 +1,6 @@
+import 'dotenv/config';
+import '../instrument.js';
+
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/src/common/http-exception.filter.ts
+++ b/src/common/http-exception.filter.ts
@@ -6,6 +6,7 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
+import { SentryExceptionCaptured } from '@sentry/nestjs';
 import { Response } from 'express';
 import { ZodSerializationException, ZodValidationException } from 'nestjs-zod';
 import { ZodError } from 'zod';
@@ -42,6 +43,7 @@ export class HttpExceptionFilter extends BaseExceptionFilter {
     super();
   }
 
+  @SentryExceptionCaptured()
   catch(exception: unknown, host: ArgumentsHost) {
     const response = host.switchToHttp().getResponse<Response>();
 

--- a/src/common/log/log.module.ts
+++ b/src/common/log/log.module.ts
@@ -1,11 +1,14 @@
 import { Global, Module } from '@nestjs/common';
 
+import { EnvModule } from '@/env/env.module';
+
 import { ContextMiddleware } from '../context/context.middleware';
 import { ContextService } from '../context/context.service';
 import { LogService } from './log.service';
 
 @Global()
 @Module({
+  imports: [EnvModule],
   providers: [LogService, ContextMiddleware, ContextService],
   exports: [LogService, ContextMiddleware, ContextService],
 })

--- a/src/common/log/log.service.ts
+++ b/src/common/log/log.service.ts
@@ -1,15 +1,24 @@
 import { Injectable } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 import { PinoLogger } from 'nestjs-pino';
+
+import { Env } from '@/env/env';
+import { EnvService } from '@/env/env.service';
 
 import { ContextService } from '../context/context.service';
 import type { ContextEvent, ContextUser } from '../types';
 
 @Injectable()
 export class LogService {
+  private readonly sentryLogs: Env['SENTRY_LOGS'];
+
   constructor(
+    private readonly env: EnvService,
     private readonly pino: PinoLogger,
     private readonly ctx: ContextService,
-  ) {}
+  ) {
+    this.sentryLogs = this.env.get('SENTRY_LOGS');
+  }
 
   setContext(name: string) {
     this.ctx.addContext({ context: name });
@@ -29,28 +38,47 @@ export class LogService {
 
   info(message: string, extras?: Record<string, any>) {
     this.pino.info(this.buildPayload(extras), message);
+    if (this.sentryLogs === 'all') {
+      Sentry.logger.info(message, extras);
+    }
   }
 
   debug(message: string, extras?: Record<string, any>) {
     this.pino.debug(this.buildPayload(extras), message);
+    if (this.sentryLogs === 'all') {
+      Sentry.logger.debug(message, extras);
+    }
   }
 
   warn(message: string, extras?: Record<string, any>) {
     this.pino.warn(this.buildPayload(extras), message);
-  }
-
-  error(message: string | object, extras?: Record<string, any>) {
-    // allow passing an object directly (exception payloads)
-    if (typeof message === 'string') {
-      this.pino.error(this.buildPayload(extras), message);
-    } else {
-      this.pino.error(this.buildPayload({ ...(extras ?? {}), ...{ message } }));
+    if (this.sentryLogs === 'all') {
+      Sentry.logger.warn(message, extras);
     }
   }
 
-  // Generic alias matching Nest's `logger.log` signature.
+  error(message: string | object, extras?: Record<string, any>) {
+    if (typeof message === 'string') {
+      this.pino.error(this.buildPayload(extras), message);
+      if (this.sentryLogs === 'all' || this.sentryLogs === 'error') {
+        Sentry.logger.error(message, extras);
+      }
+    } else {
+      this.pino.error(this.buildPayload({ ...(extras ?? {}), ...{ message } }));
+      if (this.sentryLogs === 'all' || this.sentryLogs === 'error') {
+        Sentry.logger.error('Error', {
+          ...(extras ?? {}),
+          ...(message as Record<string, any>),
+        });
+      }
+    }
+  }
+
   log(message: string, extras?: Record<string, any>) {
     this.info(message, extras);
+    if (this.sentryLogs === 'all') {
+      Sentry.logger.info(message, extras);
+    }
   }
 
   private buildPayload(extras: Record<string, any> = {}) {

--- a/src/common/log/log.service.ts
+++ b/src/common/log/log.service.ts
@@ -37,48 +37,50 @@ export class LogService {
   }
 
   info(message: string, extras?: Record<string, any>) {
-    this.pino.info(this.buildPayload(extras), message);
+    const payload = this.buildPayload(extras);
+    this.pino.info(payload, message);
     if (this.sentryLogs === 'all') {
-      Sentry.logger.info(message, extras);
+      Sentry.logger.info(message, payload);
     }
   }
 
   debug(message: string, extras?: Record<string, any>) {
-    this.pino.debug(this.buildPayload(extras), message);
+    const payload = this.buildPayload(extras);
+    this.pino.debug(payload, message);
     if (this.sentryLogs === 'all') {
-      Sentry.logger.debug(message, extras);
+      Sentry.logger.debug(message, payload);
     }
   }
 
   warn(message: string, extras?: Record<string, any>) {
-    this.pino.warn(this.buildPayload(extras), message);
+    const payload = this.buildPayload(extras);
+    this.pino.warn(payload, message);
     if (this.sentryLogs === 'all') {
-      Sentry.logger.warn(message, extras);
+      Sentry.logger.warn(message, payload);
     }
   }
 
   error(message: string | object, extras?: Record<string, any>) {
     if (typeof message === 'string') {
-      this.pino.error(this.buildPayload(extras), message);
+      const payload = this.buildPayload(extras);
+      this.pino.error(payload, message);
       if (this.sentryLogs === 'all' || this.sentryLogs === 'error') {
-        Sentry.logger.error(message, extras);
+        Sentry.logger.error(message, payload);
       }
     } else {
-      this.pino.error(this.buildPayload({ ...(extras ?? {}), ...{ message } }));
+      const payload = this.buildPayload({
+        ...(extras ?? {}),
+        ...(message as Record<string, any>),
+      });
+      this.pino.error(payload);
       if (this.sentryLogs === 'all' || this.sentryLogs === 'error') {
-        Sentry.logger.error('Error', {
-          ...(extras ?? {}),
-          ...(message as Record<string, any>),
-        });
+        Sentry.logger.error('Error', payload);
       }
     }
   }
 
   log(message: string, extras?: Record<string, any>) {
     this.info(message, extras);
-    if (this.sentryLogs === 'all') {
-      Sentry.logger.info(message, extras);
-    }
   }
 
   private buildPayload(extras: Record<string, any> = {}) {

--- a/src/env/env.ts
+++ b/src/env/env.ts
@@ -24,26 +24,6 @@ export const envSchema = z.object({
   JWT_SECRET: z.string().min(1),
   HASH_PEPPER: z.string().min(1),
 
-  // AWS
-  AWS_REGION: z.string().optional().default(''),
-  AWS_ACCESS_KEY_ID: z.string().optional().default(''),
-  AWS_SECRET_ACCESS_KEY: z.string().optional().default(''),
-
-  // Storage
-  STORAGE_ENABLED: z.enum(['true', 'false']).transform((val) => val === 'true'),
-  STORAGE_BUCKET_NAME: z.string().min(1),
-  CDN_URL: z.url(),
-  CDN_PUBLIC_KEY_ID: z.string().min(1),
-  CDN_PRIVATE_KEY: z.string().min(1),
-
-  // Database
-  DB_HOST: z.string().min(1),
-  DB_PORT: z.coerce.number(),
-  DB_DATABASE: z.string().min(1),
-  DB_USERNAME: z.string().min(1),
-  DB_PASSWORD: z.string().min(1),
-  DB_SCHEMA: z.string().optional(),
-
   // E-mails
   EMAIL_PROVIDER: z.enum(['ses', 'resend', 'none']),
   RESEND_KEY: z.string().min(1),
@@ -60,6 +40,34 @@ export const envSchema = z.object({
   CLICKSIGN_API_URL: z.url(),
   CLICKSIGN_API_KEY: z.string().min(1),
   CLICKSIGN_WEBHOOK_SECRET: z.string().min(1),
+
+  // Observability
+  SENTRY_DSN: z.string().optional().default(''),
+  SENTRY_ENABLE_LOGS: z
+    .enum(['true', 'false'])
+    .transform((val) => val === 'true')
+    .optional()
+    .default(false),
+
+  // Database
+  DB_HOST: z.string().min(1),
+  DB_PORT: z.coerce.number(),
+  DB_DATABASE: z.string().min(1),
+  DB_USERNAME: z.string().min(1),
+  DB_PASSWORD: z.string().min(1),
+  DB_SCHEMA: z.string().optional(),
+
+  // Storage
+  STORAGE_ENABLED: z.enum(['true', 'false']).transform((val) => val === 'true'),
+  STORAGE_BUCKET_NAME: z.string().min(1),
+  CDN_URL: z.url(),
+  CDN_PUBLIC_KEY_ID: z.string().min(1),
+  CDN_PRIVATE_KEY: z.string().min(1),
+
+  // AWS
+  AWS_REGION: z.string().optional().default(''),
+  AWS_ACCESS_KEY_ID: z.string().optional().default(''),
+  AWS_SECRET_ACCESS_KEY: z.string().optional().default(''),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/env/env.ts
+++ b/src/env/env.ts
@@ -43,11 +43,7 @@ export const envSchema = z.object({
 
   // Observability
   SENTRY_DSN: z.string().optional().default(''),
-  SENTRY_ENABLE_LOGS: z
-    .enum(['true', 'false'])
-    .transform((val) => val === 'true')
-    .optional()
-    .default(false),
+  SENTRY_LOGS: z.enum(['all', 'error', 'none']),
 
   // Database
   DB_HOST: z.string().min(1),

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,24 +1,36 @@
 import * as Sentry from '@sentry/nestjs';
 
 const dsn = process.env.SENTRY_DSN;
+const sentryLogs = process.env.SENTRY_LOGS;
 
-interface HttpExceptionLike {
+interface HttpException {
   getStatus?: () => number;
 }
 
 if (dsn) {
   Sentry.init({
     dsn,
-    environment: process.env.NODE_ENV,
-    enableLogs: process.env.SENTRY_ENABLE_LOGS === 'true',
     tracesSampleRate: 0,
+    environment: process.env.NODE_ENV,
+    enableLogs: sentryLogs === 'all' || sentryLogs === 'error',
     beforeSend(event, hint) {
-      const ex = hint?.originalException as HttpExceptionLike | undefined;
+      const ex = hint?.originalException as HttpException | undefined;
       if (ex && typeof ex.getStatus === 'function') {
         const status = ex.getStatus();
         if (status && status < 500) return null;
       }
       return event;
+    },
+    beforeSendLog(log) {
+      if (sentryLogs === 'none') {
+        return null;
+      }
+
+      if (sentryLogs === 'error') {
+        return log.level === 'error' ? log : null;
+      }
+
+      return log;
     },
   });
 }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,0 +1,24 @@
+import * as Sentry from '@sentry/nestjs';
+
+const dsn = process.env.SENTRY_DSN;
+
+interface HttpExceptionLike {
+  getStatus?: () => number;
+}
+
+if (dsn) {
+  Sentry.init({
+    dsn,
+    environment: process.env.NODE_ENV,
+    enableLogs: process.env.SENTRY_ENABLE_LOGS === 'true',
+    tracesSampleRate: 0,
+    beforeSend(event, hint) {
+      const ex = hint?.originalException as HttpExceptionLike | undefined;
+      if (ex && typeof ex.getStatus === 'function') {
+        const status = ex.getStatus();
+        if (status && status < 500) return null;
+      }
+      return event;
+    },
+  });
+}


### PR DESCRIPTION
## Resumo
Integra o Sentry para capturar exceções não tratadas (5xx) e encaminhar logs de erro, com filtros para excluir erros 4xx e controle via variáveis de ambiente.

## Objetivo
Monitorar erros 500 na aplicação em produção (AWS Lambda) sem poluir o dashboard do Sentry com erros de cliente (4xx). A integração é desligada por padrão — só envia dados quando a DSN é configurada.

## Principais mudanças
- Instala `@sentry/nestjs` e inicializa em `src/instrument.ts` com DSN via env
- Adiciona decorator `@SentryExceptionCaptured()` no `HttpExceptionFilter` global
- Registra `SentryModule.forRoot()` no `AppModule`
- Integra `Sentry.logger.*` no `LogService` (paralelo ao pino), com payload enriquecido (`event`, `user`, `context` do `@Log()`)
- Filtra 4xx com `beforeSend` (exceções) e `beforeSendLog` (logs) — apenas erros 5xx chegam ao Sentry
- Novas variáveis de ambiente: `SENTRY_DSN` (opcional, vazio = desligado), `SENTRY_LOGS` (`"error"` | `"all"` | `"none"`)
- Carrega `.env` manualmente no `instrument.ts` para que a DSN esteja disponível antes do bootstrap do NestJS

## Informações adicionais
- `SENTRY_DSN` deve ser configurado nas env vars da Lambda (produção/homolog) e no `.env` local
- `SENTRY_LOGS="error"` envia apenas `LogService.error()`; `"all"` envia todos os níveis
- Sem DSN, o Sentry é um no-op — seguro para ambiente de testes e repositório público
