### PR TITLE
Validate UUID path params before database layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,21 @@ export class CreateAppointmentBody extends createZodDto(
 ) {}
 ```
 
+### Path params
+
+For route params representing UUIDs (`:id`), use the shared `UUIDParams` DTO with `@Param()` destructuring:
+
+```ts
+import { UUIDParams } from '@/common/dtos';
+
+@Get(':id')
+async getById(@Param() { id }: UUIDParams, @User() user: RequestUser) {
+  // id is a validated UUID v7 string
+}
+```
+
+**Never** use `@Param('id') id: string` for UUIDs — it bypasses validation and allows invalid strings to reach the database.
+
 ### Schema reuse
 
 Prefer `.pick()`, `.extend()`, or `.merge()` from existing schemas before defining raw fields. Only create a new schema from scratch if no existing one covers the domain (e.g., a brand-new entity). This keeps schemas like `userSchema` as a single source of truth.

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -27,7 +27,7 @@ import { ZodResponse } from 'nestjs-zod';
 
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParams } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -87,7 +87,7 @@ export class AppointmentsController {
   @ApiOperation({ summary: 'Atualiza os dados do atendimento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async update(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParams,
     @User() user: RequestUser,
     @Body() body: UpdateAppointmentBody,
   ): Promise<BaseResponse> {
@@ -101,7 +101,7 @@ export class AppointmentsController {
   @ApiOperation({ summary: 'Cancela o atendimento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async cancel(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParams,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.cancelAppointmentUseCase.execute({ id, user });
@@ -183,11 +183,19 @@ async create(@Body() body: CreateAppointmentBody) { ... }
 
 ### `@Param('name')`
 
-Injeta um parâmetro de rota:
+Injeta um parâmetro de rota. Para parâmetros `:id` que representam UUIDs, use o DTO compartilhado `UUIDParams` com destructuring — o `ZodValidationPipe` global valida automaticamente o formato UUID v7:
 
 ```typescript
-async cancel(@Param('id') id: string) { ... }
+async cancel(@Param() { id }: UUIDParams) { ... }
 ```
+
+Para parâmetros que não são UUIDs, use a extração direta com `string`:
+
+```typescript
+async findByToken(@Param('token') token: string) { ... }
+```
+
+Nunca use `@Param('id') id: string` para UUIDs — isso contorna a validação e permite que strings inválidas cheguem ao banco de dados.
 
 ### `@Cookies('cookie_name')`
 

--- a/docs/dtos.md
+++ b/docs/dtos.md
@@ -105,12 +105,31 @@ Resposta padrão para rotas que não retornam dados (criação, atualização, c
 // src/common/dtos.ts
 import { createZodDto } from 'nestjs-zod';
 import { baseResponseSchema } from '@/domain/schemas/base';
+import { uuidParamsSchema } from '@/domain/schemas/shared';
 
 export class BaseResponse extends createZodDto(baseResponseSchema) {}
 // → { success: boolean; message: string }
+
+export class UUIDParams extends createZodDto(uuidParamsSchema) {}
+// → { id: string }  (UUID v7)
 ```
 
-Uso:
+## `UUIDParams`
+
+DTO compartilhado para validar parâmetros de rota `:id`. Usado com `@Param()` destructuring em controllers:
+
+```typescript
+@Get(':id')
+async getById(@Param() { id }: UUIDParams) {
+  // id é uma string UUID v7 validada pelo ZodValidationPipe global
+}
+```
+
+O schema `uuidParamsSchema` usa `uuidSchema` (`z.uuid({ version: 'v7' })`) definido em `src/domain/schemas/shared.ts`. O `ZodValidationPipe` global valida automaticamente qualquer `@Param()` tipado como `UUIDParams`.
+
+Strings inválidas retornam **400** com `"Os dados enviados são inválidos."` antes mesmo de chegar ao controller — sem round-trip ao banco.
+
+### Uso
 
 ```typescript
 @Post()
@@ -120,8 +139,6 @@ async create(@Body() body: CreateAppointmentBody): Promise<BaseResponse> {
 }
 ```
 
----
-
 ## Regras
 
 - Um único arquivo `{feature}.dtos.ts` por feature — nunca criar arquivos separados por DTO.
@@ -129,3 +146,4 @@ async create(@Body() body: CreateAppointmentBody): Promise<BaseResponse> {
 - Nunca importar schemas de outros domínios para criar DTOs — cada feature usa apenas seus schemas.
 - Para respostas tipadas com `data`, crie um schema de response em `responses.ts` e derive o DTO.
 - Nomes seguem `PascalCase` com sufixo funcional: `Body`, `Query` ou `Response`.
+- Para parâmetros de rota `:id`, use `@Param() { id }: UUIDParams` — **nunca** `@Param('id') id: string` para UUIDs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,9 @@
         "tsconfig-paths": "4.2.0",
         "typescript": "5.7.3",
         "typescript-eslint": "8.20.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@angular-devkit/core": {

--- a/src/app/http/appointments/appointments.controller.ts
+++ b/src/app/http/appointments/appointments.controller.ts
@@ -13,7 +13,7 @@ import { ZodResponse } from 'nestjs-zod';
 
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -78,7 +78,7 @@ export class AppointmentsController {
   @ApiOperation({ summary: 'Atualiza os dados do atendimento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   public async update(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
     @Body() body: UpdateAppointmentBody,
   ): Promise<BaseResponse> {
@@ -96,7 +96,7 @@ export class AppointmentsController {
   @ApiOperation({ summary: 'Cancela o atendimento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async cancel(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.cancelAppointmentUseCase.execute({ id, user });

--- a/src/app/http/patient-requirements/patient-requirements.controller.ts
+++ b/src/app/http/patient-requirements/patient-requirements.controller.ts
@@ -12,7 +12,7 @@ import { ZodResponse } from 'nestjs-zod';
 
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -101,7 +101,7 @@ export class PatientRequirementsController {
   @ApiOperation({ summary: 'Aprova a solicitação' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async approve(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.approvePatientRequirementUseCase.execute({ id, user });
@@ -118,7 +118,7 @@ export class PatientRequirementsController {
   @ApiOperation({ summary: 'Recusa a solicitação' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async decline(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.declinePatientRequirementUseCase.execute({ id, user });

--- a/src/app/http/patients/patients.controller.ts
+++ b/src/app/http/patients/patients.controller.ts
@@ -12,7 +12,7 @@ import { ZodResponse } from 'nestjs-zod';
 
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -80,7 +80,7 @@ export class PatientsController {
   @ApiOperation({ summary: 'Retorna os dados do paciente' })
   @ZodResponse({ type: GetPatientResponse, status: 200 })
   async getPatientById(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<GetPatientResponse> {
     const data = await this.getPatientUseCase.execute({ user, id });
@@ -98,7 +98,7 @@ export class PatientsController {
   @ApiOperation({ summary: 'Atualiza os dados do paciente' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async update(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
     @Body() body: UpdatePatientBody,
   ): Promise<BaseResponse> {
@@ -116,7 +116,7 @@ export class PatientsController {
   @ApiOperation({ summary: 'Inativa o paciente' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async deactivatePatient(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.deactivatePatientUseCase.execute({ id, user });

--- a/src/app/http/referrals/referrals.controller.ts
+++ b/src/app/http/referrals/referrals.controller.ts
@@ -13,7 +13,7 @@ import { ZodResponse } from 'nestjs-zod';
 
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -75,7 +75,7 @@ export class ReferralsController {
   @ApiOperation({ summary: 'Atualiza os dados do encaminhamento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   public async update(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
     @Body() body: UpdateReferralBody,
   ): Promise<BaseResponse> {
@@ -93,7 +93,7 @@ export class ReferralsController {
   @ApiOperation({ summary: 'Cancela o encaminhamento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async cancel(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.cancelReferralUseCase.execute({ id, user });

--- a/src/app/http/surveys/submissions/survey-submissions.controller.ts
+++ b/src/app/http/surveys/submissions/survey-submissions.controller.ts
@@ -13,7 +13,7 @@ import { ZodResponse } from 'nestjs-zod';
 import { Dashboard } from '@/common/decorators/dashboard.decorator';
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -70,7 +70,9 @@ export class SurveySubmissionsController {
   @Log('init_survey')
   @ApiOperation({ summary: 'Confirma o upload do documento' })
   @ZodResponse({ type: BaseResponse, status: 200 })
-  async confirmDocumentUpload(@Param('id') id: string): Promise<BaseResponse> {
+  async confirmDocumentUpload(
+    @Param() { id }: UUIDParam,
+  ): Promise<BaseResponse> {
     await this.confirmSurveySubmissionUploadUseCase.execute({ id });
 
     return {
@@ -125,7 +127,7 @@ export class SurveySubmissionsController {
   @ApiOperation({ summary: 'Detalhes de uma submissão de catalogação' })
   @ZodResponse({ type: GetSurveySubmissionResponse, status: 200 })
   async getSurveySubmissionDetails(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<GetSurveySubmissionResponse> {
     const data = await this.getSurveySubmissionUseCase.execute({ id, user });
@@ -143,7 +145,7 @@ export class SurveySubmissionsController {
   @ApiOperation({ summary: 'Aprova uma submissão de catalogação' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async approveSurveySubmission(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.approveSurveySubmissionUseCase.execute({ id, user });
@@ -160,7 +162,7 @@ export class SurveySubmissionsController {
   @ApiOperation({ summary: 'Recusa uma submissão de catalogação' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async declineSurveySubmission(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
     @Body() body: DeclineSurveySubmissionBody,
   ): Promise<BaseResponse> {

--- a/src/app/http/surveys/surveys.controller.ts
+++ b/src/app/http/surveys/surveys.controller.ts
@@ -5,7 +5,7 @@ import { ZodResponse } from 'nestjs-zod';
 import { Dashboard } from '@/common/decorators/dashboard.decorator';
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
 
@@ -66,7 +66,7 @@ export class SurveysController {
   @ApiOperation({ summary: 'Detalhes de uma catalogação' })
   @ZodResponse({ type: GetSurveyResponse, status: 200 })
   async getSurvey(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<GetSurveyResponse> {
     const data = await this.getSurveyUseCase.execute({ id, user });
@@ -84,7 +84,7 @@ export class SurveysController {
   @ApiOperation({ summary: 'Envia lembrete de assinatura ao paciente' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async sendSignRemind(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.sendSurveyReminderUseCase.execute({ id, user });

--- a/src/app/http/users/users.controller.ts
+++ b/src/app/http/users/users.controller.ts
@@ -18,7 +18,7 @@ import { ZodResponse } from 'nestjs-zod';
 
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { FileValidationPipe } from '@/common/file-validation.pipe';
 import { Log } from '@/common/log/log.decorator';
 import type { RequestUser } from '@/common/types';
@@ -114,7 +114,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Retorna os dados do usuário pelo ID' })
   @ZodResponse({ type: GetUserResponse, status: 200 })
   async getUserById(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<GetUserResponse> {
     const data = await this.getUserUseCase.execute({ id, user });
@@ -132,7 +132,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Atualiza os dados do usuário' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async updateUser(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
     @Body() body: UpdateUserBody,
   ): Promise<BaseResponse> {
@@ -150,7 +150,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Atualiza as permissões do usuário' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async updateUserFeatures(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
     @Body() body: UpdateUserFeaturesBody,
   ): Promise<BaseResponse> {
@@ -166,6 +166,7 @@ export class UsersController {
     };
   }
 
+  // TODO: update this endpoint with new upload file pattern
   @Post('upload-avatar')
   @Log('update_user')
   @RequireFeature('update:user')
@@ -201,7 +202,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Inativa o usuário' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async deactivateUser(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.deactivateUserUseCase.execute({ id, user });
@@ -218,7 +219,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Ativa o usuário' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async activateUser(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.activateUserUseCase.execute({ id, user });
@@ -252,7 +253,7 @@ export class UsersController {
   @ApiOperation({ summary: 'Exclui convite de usuário' })
   @ZodResponse({ type: BaseResponse, status: 200 })
   async cancelUserInvite(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<BaseResponse> {
     await this.cancelUserInviteUseCase.execute({ id, user });

--- a/src/app/http/webhooks/webhooks.controller.ts
+++ b/src/app/http/webhooks/webhooks.controller.ts
@@ -5,7 +5,7 @@ import { ZodResponse } from 'nestjs-zod';
 import { Public } from '@/common/decorators/public.decorator';
 import { RequireFeature } from '@/common/decorators/require-feature.decorator';
 import { User } from '@/common/decorators/user.decorator';
-import { BaseResponse } from '@/common/dtos';
+import { BaseResponse, UUIDParam } from '@/common/dtos';
 import { Log } from '@/common/log/log.decorator';
 import { LogService } from '@/common/log/log.service';
 import type { RequestUser } from '@/common/types';
@@ -54,7 +54,7 @@ export class WebhooksController {
   @ApiOperation({ summary: 'Detalhes de um evento de webhook' })
   @ZodResponse({ type: GetWebhookEventResponse, status: 200 })
   async getWebhookEvent(
-    @Param('id') id: string,
+    @Param() { id }: UUIDParam,
     @User() user: RequestUser,
   ): Promise<GetWebhookEventResponse> {
     const data = await this.getWebhookEventUseCase.execute({ id, user });

--- a/src/common/dtos.ts
+++ b/src/common/dtos.ts
@@ -1,5 +1,8 @@
 import { createZodDto } from 'nestjs-zod';
 
 import { baseResponseSchema } from '@/domain/schemas/base';
+import { uuidParamSchema } from '@/domain/schemas/shared';
 
 export class BaseResponse extends createZodDto(baseResponseSchema) {}
+
+export class UUIDParam extends createZodDto(uuidParamSchema) {}

--- a/src/domain/schemas/shared.ts
+++ b/src/domain/schemas/shared.ts
@@ -9,6 +9,8 @@ import { USER_ROLES } from '../enums/users';
 
 export const uuidSchema = z.uuid({ version: 'v7' });
 
+export const uuidParamSchema = z.object({ id: uuidSchema });
+
 export const nameSchema = z.string().min(3).max(64);
 
 // Maximum email length is 254 characters.

--- a/tests/e2e/appointments.e2e-spec.ts
+++ b/tests/e2e/appointments.e2e-spec.ts
@@ -212,7 +212,7 @@ describe('Appointments (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdateAppointmentBody>(
-        '/appointments/00000000-0000-0000-0000-000000000000',
+        '/appointments/01900000-0000-7000-8000-000000000000',
         updateBody,
         { cookies },
       );
@@ -245,7 +245,7 @@ describe('Appointments (e2e)', () => {
       const { cookies } = await createMember({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdateAppointmentBody>(
-        `/appointments/sample-id`,
+        `/appointments/01900000-0000-7000-8000-000000000000`,
         updateBody,
         { cookies },
       );
@@ -369,7 +369,7 @@ describe('Appointments (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch(
-        '/appointments/00000000-0000-0000-0000-000000000000/cancel',
+        '/appointments/01900000-0000-7000-8000-000000000000/cancel',
         undefined,
         { cookies },
       );

--- a/tests/e2e/patients.e2e-spec.ts
+++ b/tests/e2e/patients.e2e-spec.ts
@@ -237,7 +237,7 @@ describe('Patients (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.get(
-        '/patients/00000000-0000-0000-0000-000000000000',
+        '/patients/01900000-0000-7000-8000-000000000000',
         undefined,
         {
           cookies,
@@ -328,7 +328,7 @@ describe('Patients (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdatePatientBody>(
-        '/patients/00000000-0000-0000-0000-000000000000',
+        '/patients/01900000-0000-7000-8000-000000000000',
         updateBody,
         { cookies },
       );
@@ -398,7 +398,7 @@ describe('Patients (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch(
-        '/patients/00000000-0000-0000-0000-000000000000/deactivate',
+        '/patients/01900000-0000-7000-8000-000000000000/deactivate',
         undefined,
         { cookies },
       );

--- a/tests/e2e/referrals.e2e-spec.ts
+++ b/tests/e2e/referrals.e2e-spec.ts
@@ -212,7 +212,7 @@ describe('Referrals (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdateReferralBody>(
-        '/referrals/00000000-0000-0000-0000-000000000000',
+        '/referrals/01900000-0000-7000-8000-000000000000',
         updateBody,
         { cookies },
       );
@@ -247,7 +247,7 @@ describe('Referrals (e2e)', () => {
       const { cookies } = await createMember({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdateReferralBody>(
-        `/referrals/sample-id`,
+        `/referrals/01900000-0000-7000-8000-000000000000`,
         updateBody,
         { cookies },
       );
@@ -371,7 +371,7 @@ describe('Referrals (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch(
-        '/referrals/00000000-0000-0000-0000-000000000000/cancel',
+        '/referrals/01900000-0000-7000-8000-000000000000/cancel',
         undefined,
         { cookies },
       );

--- a/tests/e2e/surveys-submissions.e2e-spec.ts
+++ b/tests/e2e/surveys-submissions.e2e-spec.ts
@@ -131,7 +131,7 @@ describe('Survey Submissions (e2e)', () => {
 
     it('returns 404 for non-existent ID', async () => {
       const res = await api.post(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000/confirm-upload',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/confirm-upload',
         undefined,
         { headers },
       );
@@ -374,7 +374,7 @@ describe('Survey Submissions (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.get(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000',
         undefined,
         { cookies },
       );
@@ -456,7 +456,7 @@ describe('Survey Submissions (e2e)', () => {
       const { cookies } = await createMember({ login: true, features: [] });
 
       const res = await api.patch(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000/approve',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/approve',
         undefined,
         { cookies },
       );
@@ -472,7 +472,7 @@ describe('Survey Submissions (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000/approve',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/approve',
         undefined,
         { cookies },
       );
@@ -527,7 +527,7 @@ describe('Survey Submissions (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000/decline',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/decline',
         {},
         { cookies },
       );
@@ -563,7 +563,7 @@ describe('Survey Submissions (e2e)', () => {
       const { cookies } = await createMember({ login: true, features: [] });
 
       const res = await api.patch(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000/decline',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/decline',
         { reason: 'Documento invalido' },
         { cookies },
       );
@@ -579,7 +579,7 @@ describe('Survey Submissions (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch(
-        '/survey-submissions/00000000-0000-0000-0000-000000000000/decline',
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/decline',
         { reason: 'Documento inválido' },
         { cookies },
       );

--- a/tests/e2e/surveys.e2e-spec.ts
+++ b/tests/e2e/surveys.e2e-spec.ts
@@ -449,7 +449,7 @@ describe('Surveys (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.get(
-        '/surveys/00000000-0000-0000-0000-000000000000',
+        '/surveys/01900000-0000-7000-8000-000000000000',
         undefined,
         {
           cookies,
@@ -547,7 +547,7 @@ describe('Surveys (e2e)', () => {
       const { cookies } = await createMember({ login: true, features: [] });
 
       const res = await api.post(
-        '/surveys/sample-id/send-reminder',
+        '/surveys/01900000-0000-7000-8000-000000000000/send-reminder',
         undefined,
         { cookies },
       );
@@ -563,7 +563,7 @@ describe('Surveys (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.post(
-        '/surveys/00000000-0000-0000-0000-000000000000/send-reminder',
+        '/surveys/01900000-0000-7000-8000-000000000000/send-reminder',
         undefined,
         { cookies },
       );

--- a/tests/e2e/users.e2e-spec.ts
+++ b/tests/e2e/users.e2e-spec.ts
@@ -135,7 +135,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.get<GetUserResponse>(
-        '/users/00000000-0000-0000-0000-000000000000',
+        '/users/01900000-0000-7000-8000-000000000000',
         undefined,
         { cookies },
       );
@@ -220,7 +220,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdateUserBody>(
-        '/users/00000000-0000-0000-0000-000000000000',
+        '/users/01900000-0000-7000-8000-000000000000',
         updateBody,
         { cookies },
       );
@@ -234,7 +234,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createMember({ login: true });
 
       const res = await api.put<BaseResponseBody, UpdateUserBody>(
-        '/users/sample-id',
+        '/users/01900000-0000-7000-8000-000000000000',
         updateBody,
         { cookies },
       );
@@ -292,7 +292,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch<BaseResponseBody, UpdateUserFeaturesBody>(
-        '/users/00000000-0000-0000-0000-000000000000/features',
+        '/users/01900000-0000-7000-8000-000000000000/features',
         { features: [] },
         { cookies },
       );
@@ -306,7 +306,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createMember({ login: true });
 
       const res = await api.patch<BaseResponseBody, UpdateUserFeaturesBody>(
-        `/users/sample-id/features`,
+        `/users/01900000-0000-7000-8000-000000000000/features`,
         { features: [] },
         { cookies },
       );
@@ -346,7 +346,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch<BaseResponseBody>(
-        '/users/00000000-0000-0000-0000-000000000000/deactivate',
+        '/users/01900000-0000-7000-8000-000000000000/deactivate',
         undefined,
         { cookies },
       );
@@ -416,7 +416,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.patch<BaseResponseBody>(
-        '/users/00000000-0000-0000-0000-000000000000/activate',
+        '/users/01900000-0000-7000-8000-000000000000/activate',
         undefined,
         { cookies },
       );
@@ -608,7 +608,7 @@ describe('Users (e2e)', () => {
       });
 
       const res = await api.delete<BaseResponseBody>(
-        '/users/invites/00000000-0000-0000-0000-000000000000',
+        '/users/invites/01900000-0000-7000-8000-000000000000',
         { cookies },
       );
 
@@ -621,7 +621,7 @@ describe('Users (e2e)', () => {
       const { cookies } = await createMember({ login: true });
 
       const res = await api.delete<BaseResponseBody>(
-        '/users/invites/sample-id',
+        '/users/invites/01900000-0000-7000-8000-000000000000',
         { cookies },
       );
 

--- a/tests/e2e/webhooks.e2e-spec.ts
+++ b/tests/e2e/webhooks.e2e-spec.ts
@@ -310,7 +310,7 @@ describe('Webhooks – Signature (e2e)', () => {
       const { cookies } = await createAdmin({ login: true });
 
       const res = await api.get(
-        '/webhooks/events/00000000-0000-0000-0000-000000000000',
+        '/webhooks/events/01900000-0000-7000-8000-000000000000',
         undefined,
         { cookies },
       );


### PR DESCRIPTION
## Resumo
Valida UUIDs em parâmetros de rota antes que cheguem ao banco de dados, convertendo erros 500 do PostgreSQL em respostas 400 claras.

## Objetivo
Endpoints que recebem `:id` como path param (`GET /patients/:id`, `PUT /appointments/:id`, etc.) aceitavam qualquer string e a passavam diretamente ao TypeORM. Quando a string não era um UUID válido, o PostgreSQL lançava `QueryFailedError` (código `22P02`), que o `HttpExceptionFilter` tratava como erro inesperado → retornava **500** com `"Um erro inesperado ocorreu."`.

Agora o parâmetro é validado pelo `ZodValidationPipe` global **antes** do controller — IDs inválidos retornam **400** com `"Os dados enviados são inválidos."` + detalhes do campo.

## Principais mudanças
- Adiciona `uuidParamsSchema` (`z.object({ id: uuidSchema })`) em `src/domain/schemas/shared.ts`
- Adiciona classe `UUIDParams` via `createZodDto(uuidParamsSchema)` em `src/common/dtos.ts` — mesmo padrão do `BaseResponse`
- Atualiza 22 métodos em 8 controllers para usar `@Param() { id }: UUIDParams` com destructuring — uma linha por método, corpo permanece idêntico
- Atualiza testes e2e: substitui UUID v0 (`00000000-...`) e strings inválidas (`sample-id`) por UUID v7 válido

## Informações adicionais
Nenhuma migration ou env var nova.
