### PR TITLE
Refactor survey submission response to nest patient data and add survey URL endpoint

### DIFF
--- a/src/app/http/surveys/submissions/survey-submissions.controller.ts
+++ b/src/app/http/surveys/submissions/survey-submissions.controller.ts
@@ -24,6 +24,7 @@ import {
   GetSurveySubmissionResponse,
   GetSurveySubmissionsQuery,
   GetSurveySubmissionsResponse,
+  GetSurveyUrlResponse,
   GetTotalSurveySubmissionsQuery,
   GetTotalSurveySubmissionsResponse,
 } from './surveys.dtos';
@@ -33,6 +34,7 @@ import { CreateSurveySubmissionUseCase } from './use-cases/create-survey-submiss
 import { DeclineSurveySubmissionUseCase } from './use-cases/decline-survey-submission.use-case';
 import { GetSurveySubmissionUseCase } from './use-cases/get-survey-submission.use-case';
 import { GetSurveySubmissionsUseCase } from './use-cases/get-survey-submissions.use-case';
+import { GetSurveyUrlUseCase } from './use-cases/get-survey-url.use-case';
 import { GetTotalSurveySubmissionsUseCase } from './use-cases/get-total-survey-submissions.use-case';
 
 @ApiTags('Catalogação')
@@ -45,6 +47,7 @@ export class SurveySubmissionsController {
     private readonly declineSurveySubmissionUseCase: DeclineSurveySubmissionUseCase,
     private readonly getSurveySubmissionUseCase: GetSurveySubmissionUseCase,
     private readonly getSurveySubmissionsUseCase: GetSurveySubmissionsUseCase,
+    private readonly getSurveyUrlUseCase: GetSurveyUrlUseCase,
     private readonly getTotalSurveySubmissionsUseCase: GetTotalSurveySubmissionsUseCase,
   ) {}
 
@@ -119,6 +122,23 @@ export class SurveySubmissionsController {
       success: true,
       message: 'Total de submissões retornado com sucesso.',
       data: { total },
+    };
+  }
+
+  @Get(':id/survey-url')
+  @RequireFeature('review:survey')
+  @ApiOperation({ summary: 'Retorna a URL de preenchimento da catalogação' })
+  @ZodResponse({ type: GetSurveyUrlResponse, status: 200 })
+  async getSurveyUrl(
+    @Param() { id }: UUIDParam,
+    @User() user: RequestUser,
+  ): Promise<GetSurveyUrlResponse> {
+    const data = await this.getSurveyUrlUseCase.execute({ id, user });
+
+    return {
+      success: true,
+      message: 'URL retornada com sucesso.',
+      data,
     };
   }
 

--- a/src/app/http/surveys/submissions/surveys.dtos.ts
+++ b/src/app/http/surveys/submissions/surveys.dtos.ts
@@ -10,6 +10,7 @@ import {
   createSurveySubmissionResponseSchema,
   getSurveySubmissionResponseSchema,
   getSurveySubmissionsResponseSchema,
+  getSurveyUrlResponseSchema,
   getTotalSurveySubmissionsResponseSchema,
 } from '@/domain/schemas/surveys/submissions/responses';
 
@@ -36,6 +37,10 @@ export class GetTotalSurveySubmissionsQuery extends createZodDto(
 ) {}
 export class GetTotalSurveySubmissionsResponse extends createZodDto(
   getTotalSurveySubmissionsResponseSchema,
+) {}
+
+export class GetSurveyUrlResponse extends createZodDto(
+  getSurveyUrlResponseSchema,
 ) {}
 
 export class DeclineSurveySubmissionBody extends createZodDto(

--- a/src/app/http/surveys/submissions/use-cases/get-survey-submission.use-case.ts
+++ b/src/app/http/surveys/submissions/use-cases/get-survey-submission.use-case.ts
@@ -36,7 +36,6 @@ export class GetSurveySubmissionUseCase {
           key: true,
           url: true,
           name: true,
-          filename: true,
           size: true,
           mimeType: true,
         },
@@ -55,18 +54,20 @@ export class GetSurveySubmissionUseCase {
 
     return {
       id: submission.id,
-      name: submission.patient.name,
-      email: submission.patient.email,
-      phone: submission.patient.phone || '',
       status: submission.status,
       reason: submission.reason,
       fillingMethod: submission.fillingMethod,
+      patient: {
+        id: submission.patient.id,
+        name: submission.patient.name,
+        email: submission.patient.email,
+        phone: submission.patient.phone || '',
+      },
       document: submission.document
         ? {
             key: submission.document.key,
             url: submission.document.url,
             name: submission.document.name,
-            filename: submission.document.filename,
             size: submission.document.size,
             mimeType: submission.document.mimeType,
           }

--- a/src/app/http/surveys/submissions/use-cases/get-survey-submissions.use-case.ts
+++ b/src/app/http/surveys/submissions/use-cases/get-survey-submissions.use-case.ts
@@ -118,13 +118,16 @@ export class GetSurveySubmissionsUseCase {
     return {
       submissions: result.map((submission) => ({
         id: submission.id,
-        name: submission.patient.name,
-        email: submission.patient.email,
-        phone: submission.patient.phone || '',
         status: submission.status,
         reason: submission.reason,
         fillingMethod: submission.fillingMethod,
         createdAt: submission.createdAt,
+        patient: {
+          id: submission.patient.id,
+          name: submission.patient.name,
+          email: submission.patient.email,
+          phone: submission.patient.phone || '',
+        },
         document: submission.document
           ? { name: submission.document.name, url: submission.document.url }
           : null,

--- a/src/app/http/surveys/submissions/use-cases/get-survey-url.use-case.ts
+++ b/src/app/http/surveys/submissions/use-cases/get-survey-url.use-case.ts
@@ -1,0 +1,62 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { can } from '@/common/authorization/can';
+import type { RequestUser } from '@/common/types';
+import { SurveySubmission } from '@/domain/entities/survey-submission';
+import { EnvService } from '@/env/env.service';
+
+interface GetSurveyUrlUseCaseInput {
+  user: RequestUser;
+  id: string;
+}
+
+interface GetSurveyUrlUseCaseOutput {
+  url: string;
+}
+
+@Injectable()
+export class GetSurveyUrlUseCase {
+  private readonly dashboardUrl: string;
+
+  constructor(
+    @InjectRepository(SurveySubmission)
+    private readonly surveySubmissionsRepository: Repository<SurveySubmission>,
+    private readonly envService: EnvService,
+  ) {
+    this.dashboardUrl = this.envService.get('DASHBOARD_URL');
+  }
+
+  async execute({
+    user,
+    id,
+  }: GetSurveyUrlUseCaseInput): Promise<GetSurveyUrlUseCaseOutput> {
+    can(user, 'review:survey');
+
+    const submission = await this.surveySubmissionsRepository.findOne({
+      select: { id: true, status: true, surveyToken: true },
+      where: { id },
+    });
+
+    if (!submission) {
+      throw new NotFoundException('Submissão de catalogação não encontrada.', {
+        cause: `Survey submission with ID <${id}> not found`,
+      });
+    }
+
+    if (submission.status !== 'approved') {
+      throw new BadRequestException('A submissão ainda não foi aprovada.', {
+        cause: `Survey submission with ID <${id}> has status "${submission.status}", expected "approved"`,
+      });
+    }
+
+    const url = `${this.dashboardUrl}/catalogacao/voce?token=${submission.surveyToken}`;
+
+    return { url };
+  }
+}

--- a/src/app/http/surveys/surveys.module.ts
+++ b/src/app/http/surveys/surveys.module.ts
@@ -18,6 +18,7 @@ import { CreateSurveySubmissionUseCase } from './submissions/use-cases/create-su
 import { DeclineSurveySubmissionUseCase } from './submissions/use-cases/decline-survey-submission.use-case';
 import { GetSurveySubmissionUseCase } from './submissions/use-cases/get-survey-submission.use-case';
 import { GetSurveySubmissionsUseCase } from './submissions/use-cases/get-survey-submissions.use-case';
+import { GetSurveyUrlUseCase } from './submissions/use-cases/get-survey-url.use-case';
 import { GetTotalSurveySubmissionsUseCase } from './submissions/use-cases/get-total-survey-submissions.use-case';
 import { SurveysController } from './surveys.controller';
 import { CompleteSurveyUseCase } from './use-cases/complete-survey.use-case';
@@ -45,6 +46,7 @@ import { SendSurveyReminderUseCase } from './use-cases/send-survey-reminder.use-
     DeclineSurveySubmissionUseCase,
     GetSurveySubmissionUseCase,
     GetSurveySubmissionsUseCase,
+    GetSurveyUrlUseCase,
     GetSurveyUseCase,
     GetSurveysUseCase,
     GetTotalSurveySubmissionsUseCase,

--- a/src/domain/schemas/surveys/submissions/responses.ts
+++ b/src/domain/schemas/surveys/submissions/responses.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import { baseResponseSchema } from '../../base';
 import { documentSchema } from '../../documents';
 import { patientSchema } from '../../patients';
-import { emailSchema, nameSchema, phoneSchema } from '../../shared';
 import { surveySubmissionSchema } from '.';
 
 export const createSurveySubmissionResponseSchema = baseResponseSchema
@@ -52,15 +51,17 @@ export const surveySubmissionDetailsResponseSchema = z.strictObject({
     updatedAt: true,
     createdAt: true,
   }).shape,
-  name: nameSchema,
-  email: emailSchema,
-  phone: phoneSchema,
+  patient: patientSchema.pick({
+    id: true,
+    name: true,
+    email: true,
+    phone: true,
+  }),
   document: documentSchema
     .pick({
       key: true,
-      url: true,
       name: true,
-      filename: true,
+      url: true,
       size: true,
       mimeType: true,
     })

--- a/src/domain/schemas/surveys/submissions/responses.ts
+++ b/src/domain/schemas/surveys/submissions/responses.ts
@@ -75,6 +75,10 @@ export const getSurveySubmissionResponseSchema = baseResponseSchema.extend({
   data: surveySubmissionDetailsResponseSchema,
 });
 
+export const getSurveyUrlResponseSchema = baseResponseSchema.extend({
+  data: z.strictObject({ url: z.string() }),
+});
+
 export const getTotalSurveySubmissionsResponseSchema = z.strictObject({
   ...baseResponseSchema.shape,
   data: z.strictObject({ total: z.number() }),

--- a/src/domain/schemas/surveys/submissions/responses.ts
+++ b/src/domain/schemas/surveys/submissions/responses.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { baseResponseSchema } from '../../base';
 import { documentSchema } from '../../documents';
+import { patientSchema } from '../../patients';
 import { emailSchema, nameSchema, phoneSchema } from '../../shared';
 import { surveySubmissionSchema } from '.';
 
@@ -23,9 +24,12 @@ export const surveySubmissionResponseSchema = z.strictObject({
     fillingMethod: true,
     createdAt: true,
   }).shape,
-  name: nameSchema,
-  email: emailSchema,
-  phone: phoneSchema,
+  patient: patientSchema.pick({
+    id: true,
+    name: true,
+    email: true,
+    phone: true,
+  }),
   document: documentSchema.pick({ name: true, url: true }).nullable(),
 });
 export type SurveySubmissionResponse = z.infer<

--- a/tests/e2e/surveys-submissions.e2e-spec.ts
+++ b/tests/e2e/surveys-submissions.e2e-spec.ts
@@ -245,7 +245,7 @@ describe('Survey Submissions (e2e)', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.data.submissions).toHaveLength(1);
-      expect(res.body.data.submissions[0].name).toBe('Searchable Name');
+      expect(res.body.data.submissions[0].patient.name).toBe('Searchable Name');
       expect(res.body.data.total).toBe(1);
     });
 

--- a/tests/e2e/surveys-submissions.e2e-spec.ts
+++ b/tests/e2e/surveys-submissions.e2e-spec.ts
@@ -347,8 +347,8 @@ describe('Survey Submissions (e2e)', () => {
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(true);
       expect(res.body.data.id).toBe(submission.id);
-      expect(res.body.data.name).toBe(patient.name);
-      expect(res.body.data.email).toBe(patient.email);
+      expect(res.body.data.patient.name).toBe(patient.name);
+      expect(res.body.data.patient.email).toBe(patient.email);
       expect(res.body.data.status).toBe(submission.status);
     });
 

--- a/tests/e2e/surveys-submissions.e2e-spec.ts
+++ b/tests/e2e/surveys-submissions.e2e-spec.ts
@@ -5,6 +5,7 @@ import type {
   CreateSurveySubmissionResponse,
   GetSurveySubmissionResponse,
   GetSurveySubmissionsResponse,
+  GetSurveyUrlResponse,
   GetTotalSurveySubmissionsResponse,
 } from '@/app/http/surveys/submissions/surveys.dtos';
 import { MailService } from '@/app/mail/mail.service';
@@ -376,6 +377,84 @@ describe('Survey Submissions (e2e)', () => {
 
       const res = await api.get(
         '/survey-submissions/01900000-0000-7000-8000-000000000000',
+        undefined,
+        { cookies },
+      );
+
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe('Submissão de catalogação não encontrada.');
+    });
+  });
+
+  describe('GET /survey-submissions/:id/survey-url', () => {
+    it('returns survey URL for approved submission', async () => {
+      const { cookies } = await createMember({
+        login: true,
+        features: ['review:survey'],
+      });
+
+      const { patient } = await createPatient();
+      const submission = await createSurveySubmission({
+        status: 'approved',
+        surveyToken: '01900000-0000-7000-8000-000000000001',
+        patient,
+      });
+
+      const res = await api.get<GetSurveyUrlResponse>(
+        `/survey-submissions/${submission.id}/survey-url`,
+        undefined,
+        { cookies },
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data.url).toContain(
+        '/catalogacao/voce?token=01900000-0000-7000-8000-000000000001',
+      );
+    });
+
+    it('returns 400 for non-approved submission', async () => {
+      const { cookies } = await createAdmin({ login: true });
+
+      const { patient } = await createPatient();
+      const submission = await createSurveySubmission({
+        status: 'pending_review',
+        patient,
+      });
+
+      const res = await api.get(
+        `/survey-submissions/${submission.id}/survey-url`,
+        undefined,
+        { cookies },
+      );
+
+      expect(res.status).toBe(400);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe('A submissão ainda não foi aprovada.');
+    });
+
+    it('blocks user without "review:survey" feature', async () => {
+      const { cookies } = await createMember({ login: true, features: [] });
+
+      const res = await api.get(
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/survey-url',
+        undefined,
+        { cookies },
+      );
+
+      expect(res.status).toBe(403);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe(
+        'Você não tem permissão para executar esta ação.',
+      );
+    });
+
+    it('returns 404 for non-existent ID', async () => {
+      const { cookies } = await createAdmin({ login: true });
+
+      const res = await api.get(
+        '/survey-submissions/01900000-0000-7000-8000-000000000000/survey-url',
         undefined,
         { cookies },
       );

--- a/tests/unit/use-cases/surveys/submissions/get-survey-submission.use-case.spec.ts
+++ b/tests/unit/use-cases/surveys/submissions/get-survey-submission.use-case.spec.ts
@@ -66,15 +66,17 @@ describe('GetSurveySubmissionUseCase', () => {
     );
     expect(result).toMatchObject({
       id: 'sub-1',
-      name: 'Alice',
-      email: 'alice@example.com',
-      phone: '11999999999',
       status: 'pending_review',
+      patient: {
+        id: 'pat-1',
+        name: 'Alice',
+        email: 'alice@example.com',
+        phone: '11999999999',
+      },
       document: {
         key: 'path/file.pdf',
         url: 'https://cdn.example.com/file.pdf',
         name: 'Laudo',
-        filename: 'file.pdf',
         size: 1024,
         mimeType: 'application/pdf',
       },

--- a/tests/unit/use-cases/surveys/submissions/get-survey-submissions.use-case.spec.ts
+++ b/tests/unit/use-cases/surveys/submissions/get-survey-submissions.use-case.spec.ts
@@ -55,13 +55,16 @@ describe('GetSurveySubmissionsUseCase', () => {
     expect(result.submissions).toEqual([
       {
         id: 'sub-1',
-        name: 'Alice',
-        email: 'alice@example.com',
-        phone: '11999999999',
         status: 'pending_document',
         reason: null,
         fillingMethod: submission.fillingMethod,
         createdAt: submission.createdAt,
+        patient: {
+          id: 'pat-1',
+          name: 'Alice',
+          email: 'alice@example.com',
+          phone: '11999999999',
+        },
         document: null,
       },
     ]);

--- a/tests/unit/use-cases/surveys/submissions/get-survey-url.use-case.spec.ts
+++ b/tests/unit/use-cases/surveys/submissions/get-survey-url.use-case.spec.ts
@@ -1,0 +1,99 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { mock, MockProxy } from 'jest-mock-extended';
+import { requestUserFactory } from 'tests/config/factories/shared.factory';
+import { surveySubmissionFactory } from 'tests/config/factories/survey-submission.factory';
+import { patientUserFactory } from 'tests/config/factories/user.factory';
+import { Repository } from 'typeorm';
+
+import { GetSurveyUrlUseCase } from '@/app/http/surveys/submissions/use-cases/get-survey-url.use-case';
+import { SurveySubmission } from '@/domain/entities/survey-submission';
+import { EnvService } from '@/env/env.service';
+
+const adminUser = requestUserFactory({ role: 'admin', features: [] });
+
+describe('GetSurveyUrlUseCase', () => {
+  let useCase: GetSurveyUrlUseCase;
+  let repo: MockProxy<Repository<SurveySubmission>>;
+  let env: MockProxy<EnvService>;
+
+  const patient = patientUserFactory({
+    id: 'pat-1',
+    name: 'Alice',
+    email: 'alice@example.com',
+  });
+
+  const approvedSubmission = surveySubmissionFactory({
+    patient,
+    id: 'sub-1',
+    status: 'approved',
+    surveyToken: '01900000-0000-7000-8000-000000000001',
+  });
+
+  beforeEach(async () => {
+    repo = mock<Repository<SurveySubmission>>();
+    env = mock<EnvService>();
+
+    env.get.mockReturnValue('https://example.com');
+
+    const module = await Test.createTestingModule({
+      providers: [
+        GetSurveyUrlUseCase,
+        { provide: getRepositoryToken(SurveySubmission), useValue: repo },
+        { provide: EnvService, useValue: env },
+      ],
+    }).compile();
+
+    useCase = module.get(GetSurveyUrlUseCase);
+  });
+
+  it('returns survey URL for approved submission', async () => {
+    repo.findOne.mockResolvedValue(
+      approvedSubmission as unknown as SurveySubmission,
+    );
+
+    const result = await useCase.execute({ user: adminUser, id: 'sub-1' });
+
+    expect(result).toEqual({
+      url: 'https://example.com/catalogacao/voce?token=01900000-0000-7000-8000-000000000001',
+    });
+  });
+
+  it('throws "BadRequestException" when submission is not approved', async () => {
+    const pendingSubmission = surveySubmissionFactory({
+      patient,
+      id: 'sub-2',
+      status: 'pending_review',
+      surveyToken: null,
+    });
+
+    repo.findOne.mockResolvedValue(
+      pendingSubmission as unknown as SurveySubmission,
+    );
+
+    await expect(
+      useCase.execute({ user: adminUser, id: 'sub-2' }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws "NotFoundException" when submission not found', async () => {
+    repo.findOne.mockResolvedValue(null);
+
+    await expect(
+      useCase.execute({ user: adminUser, id: 'nonexistent' }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('throws "ForbiddenException" without "review:survey" feature', async () => {
+    const memberUser = requestUserFactory({ role: 'member', features: [] });
+
+    await expect(
+      useCase.execute({ user: memberUser, id: 'sub-1' }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});


### PR DESCRIPTION
## Resumo
Reorganiza as respostas das submissões de catalogação para usar um objeto `patient` aninhado em vez de campos planos, remove o campo `filename` do documento nos detalhes, e adiciona um novo endpoint `GET :id/survey-url` para obter o link de preenchimento do formulário.

## Objetivo
As respostas da API de listagem e detalhes de submissões expunham `name`, `email` e `phone` como campos planos. Com a padronização de objetos aninhados para relações, esses campos foram movidos para dentro de um objeto `patient`. Além disso, membros com a feature `review:survey` precisavam de uma forma de obter o link da catalogação manualmente, sem depender do e-mail enviado na aprovação.

## Principais mudanças
- `surveySubmissionResponseSchema` (listagem): `name`/`email`/`phone` movidos para `patient: { id, name, email, phone }`
- `surveySubmissionDetailsResponseSchema` (detalhes): mesma alteração + remoção do `filename` do documento
- Novo `GetSurveyUrlUseCase`: retorna `{ url: "..." }` apenas para submissões aprovadas
- Novo endpoint `GET /survey-submissions/:id/survey-url` com `@RequireFeature('review:survey')`
- Atualizados use cases, DTOs, módulo, testes unitários e e2e

## Informações adicionais
Nenhuma migration necessária. Breaking change na resposta de listagem e detalhes — os campos `name`, `email`, `phone` no nível raiz foram movidos para `patient.name`, `patient.email`, `patient.phone`. Frontend que consome esses endpoints precisa ser atualizado.