### PR TITLE
Fix Sentry event delivery on Lambdas and webhook error reporting

### DIFF
--- a/src/app/http/webhooks/use-cases/survey-signature-webhook.use-case.ts
+++ b/src/app/http/webhooks/use-cases/survey-signature-webhook.use-case.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import * as Sentry from '@sentry/nestjs';
 
 import { CompleteSurveyUseCase } from '@/app/http/surveys/use-cases/complete-survey.use-case';
 import { Log } from '@/common/log/log.decorator';
@@ -31,26 +32,22 @@ export class SurveySignatureWebhookUseCase {
     const documentStatus = payload.document.status;
     const logData = { eventName, documentKey, documentStatus };
 
-    this.logger.log('ClickSign webhook received', logData);
+    this.logger.log('Signature webhook received', logData);
 
     const metadataKey = payload.document.metadata?.key;
 
     if (metadataKey !== SURVEY_SIGNATURE_METADATA_KEY) {
-      this.logger.log('ClickSign webhook bypassed – metadata key mismatch', {
+      this.logger.log('Signature webhook bypassed – metadata key mismatch', {
         ...logData,
         metadataKey,
       });
       return;
     }
 
-    const CLICKSIGN_COMPLETION_EVENTS = [
-      'auto_close',
-      'close',
-      'document_closed',
-    ];
+    const COMPLETION_EVENTS = ['auto_close', 'close', 'document_closed'];
 
-    if (!CLICKSIGN_COMPLETION_EVENTS.includes(eventName)) {
-      this.logger.log('ClickSign webhook bypassed – event mismatch', logData);
+    if (!COMPLETION_EVENTS.includes(eventName)) {
+      this.logger.log('Signature webhook bypassed – event mismatch', logData);
       return;
     }
 
@@ -58,7 +55,19 @@ export class SurveySignatureWebhookUseCase {
       await this.completeSurveyUseCase.execute({
         signatureDocumentId: documentKey,
       });
-    } catch {
+    } catch (error) {
+      this.logger.error('Failed to complete survey from signature webhook', {
+        ...logData,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      Sentry.captureException(error, {
+        captureContext: {
+          level: 'error',
+          extra: { eventName, documentKey, documentStatus },
+        },
+      });
+
       await this.updateWebhookEventStatusUseCase.execute({
         id: webhookEventId,
         status: 'failed',

--- a/src/app/lambda.ts
+++ b/src/app/lambda.ts
@@ -5,6 +5,7 @@ import type { RequestListener } from 'node:http';
 
 import { INestApplication } from '@nestjs/common';
 import { ExpressAdapter } from '@nestjs/platform-express';
+import * as Sentry from '@sentry/nestjs';
 import serverlessExpress from '@vendia/serverless-express';
 import { APIGatewayProxyEvent, Callback, Context } from 'aws-lambda';
 import express from 'express';
@@ -34,5 +35,9 @@ export const handler = async (
     });
   }
 
-  return cachedHandler(event, context, callback);
+  try {
+    return await cachedHandler(event, context, callback);
+  } finally {
+    await Sentry.flush(1000);
+  }
 };

--- a/src/app/signature/use-cases/request-signature.use-case.ts
+++ b/src/app/signature/use-cases/request-signature.use-case.ts
@@ -95,14 +95,14 @@ export class RequestSignatureUseCase {
         data: {
           type: 'signers',
           attributes: {
-            documentation: signer.cpf,
-            email: signer.email,
             name: signer.fullName,
+            email: signer.email,
             phone_number: signer.phone,
+            documentation: signer.cpf,
             communicate_events: {
               signature_request: channel,
               signature_reminder: channel === 'whatsapp' ? 'none' : 'email',
-              document_signed: channel === 'whatsapp' ? 'whatsapp' : 'email',
+              document_signed: channel,
             },
           },
         },
@@ -130,7 +130,7 @@ export class RequestSignatureUseCase {
       method: 'POST',
       data: {
         type: 'requirements',
-        attributes: { action: 'provide_evidence', auth: 'email' },
+        attributes: { action: 'provide_evidence', auth: channel },
         relationships: {
           document: { data: { type: 'documents', id: documentId } },
           signer: { data: { type: 'signers', id: signerId } },

--- a/src/shared/queue/create-handler.ts
+++ b/src/shared/queue/create-handler.ts
@@ -114,7 +114,7 @@ export function createQueueWorkerHandler(
       }
     }
 
-    await Sentry.flush(1500);
+    await Sentry.flush(1000);
 
     return { batchItemFailures };
   };

--- a/tests/unit/use-cases/webhooks/survey-signature-webhook.use-case.spec.ts
+++ b/tests/unit/use-cases/webhooks/survey-signature-webhook.use-case.spec.ts
@@ -2,6 +2,12 @@ import { NotFoundException } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { mock, MockProxy } from 'jest-mock-extended';
 
+const mockSentryCaptureException = jest.fn();
+
+jest.mock('@sentry/nestjs', () => ({
+  captureException: mockSentryCaptureException,
+}));
+
 import { CompleteSurveyUseCase } from '@/app/http/surveys/use-cases/complete-survey.use-case';
 import { SurveySignatureWebhookUseCase } from '@/app/http/webhooks/use-cases/survey-signature-webhook.use-case';
 import { UpdateWebhookEventStatusUseCase } from '@/app/http/webhooks/use-cases/update-webhook-event-status.use-case';
@@ -36,6 +42,7 @@ describe('SurveySignatureWebhookUseCase', () => {
     completeSurveyUseCase = mock<CompleteSurveyUseCase>();
     updateWebhookEventStatusUseCase = mock<UpdateWebhookEventStatusUseCase>();
     logger = mock<LogService>();
+    mockSentryCaptureException.mockClear();
 
     const module = await Test.createTestingModule({
       providers: [
@@ -114,15 +121,30 @@ describe('SurveySignatureWebhookUseCase', () => {
     });
   });
 
-  it('catches "NotFoundException" and marks webhook event as failed', async () => {
-    completeSurveyUseCase.execute.mockRejectedValue(
-      new NotFoundException(
-        'Nenhuma catalogação encontrada para esta assinatura.',
-      ),
+  it('logs the error and reports it to Sentry when "CompleteSurveyUseCase" fails', async () => {
+    const error = new NotFoundException(
+      'Nenhuma catalogação encontrada para esta assinatura.',
     );
+    completeSurveyUseCase.execute.mockRejectedValue(error);
 
     await expect(useCase.execute(makePayload())).resolves.toBeUndefined();
 
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to complete survey from signature webhook',
+      expect.objectContaining({
+        error: 'Nenhuma catalogação encontrada para esta assinatura.',
+      }),
+    );
+    expect(mockSentryCaptureException).toHaveBeenCalledWith(error, {
+      captureContext: {
+        level: 'error',
+        extra: {
+          eventName: 'auto_close',
+          documentKey: DOCUMENT_KEY,
+          documentStatus: 'closed',
+        },
+      },
+    });
     expect(updateWebhookEventStatusUseCase.execute).toHaveBeenCalledWith({
       id: WEBHOOK_EVENT_ID,
       status: 'failed',


### PR DESCRIPTION
## Resumo
Corrige a entrega de issues e logs do Sentry nas Lambdas (API e workers) e faz o webhook de assinatura de catálogo reportar falhas ao Sentry; também passa a usar o canal configurado nas notificações de assinatura.

## Objetivo
Erros engolidos no webhook de assinatura não geravam log nem alerta no Sentry. Além disso, no ambiente Lambda o congelamento do container após a resposta (`callbackWaitsForEmptyEventLoop = false`) fazia o buffer de logs do Sentry (5s) nunca ser enviado e tornava a entrega de issues uma corrida contra o freeze — erros em endpoints raros (como webhooks) se perdiam.

## Principais mudanças
- `SurveySignatureWebhookUseCase`: o `catch` agora loga o erro e chama `Sentry.captureException` antes de marcar o evento do webhook como `failed` (com teste unitário cobrindo log e captura)
- `src/app/lambda.ts`: `await Sentry.flush(1000)` no `finally` do handler da API, garantindo a entrega de issues e logs antes do congelamento do container
- `src/shared/queue/create-handler.ts`: timeout de flush dos workers alinhado de 1500ms para 1000ms
- `RequestSignatureUseCase`: usa `channel` para `document_signed` e para o `auth` do requirement de evidência, em vez de valores fixos
- Mensagens de log do webhook renomeadas de ClickSign para nomenclatura genérica de assinatura

## Informações adicionais
- Requer `SENTRY_DSN` e `SENTRY_LOGS=error` configurados no ambiente da Lambda (já estão no ambiente atual)
- Para testar: disparar o webhook de assinatura com um `documentKey` inexistente e conferir no Sentry a issue `[api] NotFoundException` e o log de erro `[api] Failed to complete survey from signature webhook`
- O flush roda após a resposta ser enviada, então não adiciona latência visível ao cliente — apenas tempo de execução cobrado em caminhos de erro
